### PR TITLE
Implement "om node version"

### DIFF
--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -1247,6 +1247,17 @@ func newCmdNodeUnset() *cobra.Command {
 	return cmd
 }
 
+func newCmdNodeVersion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "display agent version",
+		Run: func(cmd *cobra.Command, args []string) {
+			commands.CmdNodeVersion()
+		},
+	}
+	return cmd
+}
+
 func newCmdNodeValidate() *cobra.Command {
 	var options commands.CmdNodeValidateConfig
 	cmd := &cobra.Command{
@@ -1294,7 +1305,7 @@ func newCmdObjectAbort(kind string) *cobra.Command {
 func newCmdObjectBoot(kind string) *cobra.Command {
 	var options commands.CmdObjectBoot
 	cmd := &cobra.Command{
-		Use:   "boot",
+		Use: "boot",
 		Short: "Clean up actions executed before the daemon starts." +
 			" For example scsi reservation release and vg tags removal." +
 			" Never execute this action manually.",

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -121,6 +121,7 @@ func init() {
 		newCmdNodeSysreport(),
 		newCmdNodeUnfreeze(),
 		newCmdNodeUnset(),
+		newCmdNodeVersion(),
 	)
 	cmdNodePrint.AddCommand(
 		newCmdNodePrintConfig(),

--- a/core/commands/node_version.go
+++ b/core/commands/node_version.go
@@ -1,0 +1,12 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/opensvc/om3/util/version"
+)
+
+func CmdNodeVersion() {
+	v := version.Version()
+	fmt.Println(v)
+}

--- a/core/object/node_push_asset.go
+++ b/core/object/node_push_asset.go
@@ -3,12 +3,12 @@ package object
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-	"github.com/opensvc/om3/core/version"
 	"github.com/opensvc/om3/util/asset"
 	"github.com/opensvc/om3/util/hostname"
 	"github.com/opensvc/om3/util/key"
 	"github.com/opensvc/om3/util/san"
+	"github.com/opensvc/om3/util/version"
+	"github.com/pkg/errors"
 )
 
 type (
@@ -51,7 +51,7 @@ func (t Node) assetValueFromProbe(kw string, title string, probe prober, dflt in
 func (t Node) assetAgentVersion() (data asset.Value) {
 	data.Title = "agent version"
 	data.Source = asset.SrcProbe
-	data.Value = version.Version
+	data.Value = version.Version()
 	return
 }
 

--- a/core/version/main.go
+++ b/core/version/main.go
@@ -1,3 +1,0 @@
-package version
-
-var Version = "dev"

--- a/util/version/main.go
+++ b/util/version/main.go
@@ -1,28 +1,17 @@
 package version
 
 import (
-	_ "embed"
+	"embed"
 	"runtime/debug"
 	"strings"
 )
 
 var (
-	//go:embed VERSION
-	ExplicitVersion string
+	//go:embed text
+	fs embed.FS
 )
 
-// Version returns a string containing either the content of
-// util/version/VERSION (which is created or updated by the
-// packaging automation), or the build info release (ie the
-// git HEAD commit id at build time).
-//
-// Example VERSION generation:
-//
-//	git describe --tags >util/version/VERSION
-func Version() string {
-	if ExplicitVersion != "" {
-		return strings.TrimSpace(ExplicitVersion)
-	}
+func BuildVersion() string {
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, setting := range info.Settings {
 			if setting.Key == "vcs.revision" {
@@ -31,4 +20,28 @@ func Version() string {
 		}
 	}
 	return ""
+}
+
+func ExplicitVersion() string {
+	if b, err := fs.ReadFile("text/VERSION"); err == nil {
+		s := string(b)
+		return strings.TrimSpace(s)
+	}
+	return ""
+}
+
+// Version returns a string containing either the content of
+// util/version/text/VERSION (which is created or updated by the
+// packaging automation), or the build info release (ie the git
+// HEAD commit id at build time).
+//
+// Example VERSION generation:
+//
+//	git describe --tags >util/version/VERSION
+func Version() string {
+	if v := ExplicitVersion(); v != "" {
+		return v
+	} else {
+		return BuildVersion()
+	}
 }

--- a/util/version/main.go
+++ b/util/version/main.go
@@ -1,0 +1,34 @@
+package version
+
+import (
+	_ "embed"
+	"runtime/debug"
+	"strings"
+)
+
+var (
+	//go:embed VERSION
+	ExplicitVersion string
+)
+
+// Version returns a string containing either the content of
+// util/version/VERSION (which is created or updated by the
+// packaging automation), or the build info release (ie the
+// git HEAD commit id at build time).
+//
+// Example VERSION generation:
+//
+//	git describe --tags >util/version/VERSION
+func Version() string {
+	if ExplicitVersion != "" {
+		return strings.TrimSpace(ExplicitVersion)
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				return setting.Value
+			}
+		}
+	}
+	return ""
+}

--- a/util/version/text/README
+++ b/util/version/text/README
@@ -1,0 +1,2 @@
+Create a VERSION file in this directory from the packaging automation.
+On build, this VERSION is embeded.


### PR DESCRIPTION
version.Version() returns a string containing either the content of util/version/VERSION (which is created or updated by the packaging automation), or the build info release (ie the git HEAD commit id at build time).

Example VERSION file generation:

    git describe --tags >util/version/VERSION