### PR TITLE
daemon publish Exec, ExecFailed, ExecSuccess crm actions

### DIFF
--- a/daemon/msgbus/messages.go
+++ b/daemon/msgbus/messages.go
@@ -42,6 +42,12 @@ var (
 
 		"DaemonStart": func() any { return &DaemonStart{} },
 
+		"Exec": func() any { return &Exec{} },
+
+		"ExecFailed": func() any { return &ExecFailed{} },
+
+		"ExecSuccess": func() any { return &ExecSuccess{} },
+
 		"Exit": func() any { return &Exit{} },
 
 		"ForgetPeer": func() any { return &ForgetPeer{} },
@@ -244,6 +250,42 @@ type (
 		pubsub.Msg `yaml:",inline"`
 		Node       string `json:"node" yaml:"node"`
 		Version    string `json:"version" yaml:"version"`
+	}
+
+	// Exec message describes an exec call
+	Exec struct {
+		pubsub.Msg `yaml:",inline"`
+		Command string `json:"command" yaml:"command"`
+		// Node is the nodename that will call exec
+		Node string `json:"node" yaml:"node"`
+		// Origin describes the exec caller: example: imon, nmon, scheduler...
+		Origin string `json:"origin" yaml:"origin"`
+		Title  string `json:"title" yaml:"title"`
+	}
+
+	// ExecFailed message describes failed exec call
+	ExecFailed struct {
+		pubsub.Msg `yaml:",inline"`
+		Command  string        `json:"command" yaml:"command"`
+		Duration time.Duration `json:"duration" yaml:"duration"`
+		ErrS     string        `json:"error" yaml:"error"`
+		// Node is the nodename that called exec
+		Node string `json:"node" yaml:"node"`
+		// Origin describes the exec caller: example: imon, nmon, scheduler...
+		Origin string `json:"origin" yaml:"origin"`
+		Title  string `json:"title" yaml:"title"`
+	}
+
+	// ExecSuccess message describes successfully exec call
+	ExecSuccess struct {
+		pubsub.Msg `yaml:",inline"`
+		Command  string        `json:"command" yaml:"command"`
+		Duration time.Duration `json:"duration" yaml:"duration"`
+		// Node is the nodename that called exec
+		Node string `json:"node" yaml:"node"`
+		// Origin describes the exec caller: example: imon, nmon, scheduler...
+		Origin string `json:"origin" yaml:"origin"`
+		Title  string `json:"title" yaml:"title"`
 	}
 
 	Exit struct {
@@ -703,6 +745,18 @@ func (e *DaemonHb) Kind() string {
 
 func (e *DaemonStart) Kind() string {
 	return "DaemonStart"
+}
+
+func (e *Exec) Kind() string {
+	return "Exec"
+}
+
+func (e *ExecFailed) Kind() string {
+	return "ExecFailed"
+}
+
+func (e *ExecSuccess) Kind() string {
+	return "ExecSuccess"
 }
 
 func (e *Exit) Kind() string {

--- a/daemon/scheduler/jobs.go
+++ b/daemon/scheduler/jobs.go
@@ -3,18 +3,24 @@ package scheduler
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/opensvc/om3/core/env"
 	"github.com/opensvc/om3/core/schedule"
+	"github.com/opensvc/om3/daemon/msgbus"
 	"github.com/opensvc/om3/util/command"
+	"github.com/opensvc/om3/util/pubsub"
 )
 
 func (o T) action(e schedule.Entry) error {
+	labels := []pubsub.Label{{"node", o.localhost}, {"origin", "scheduler"}}
 	cmdArgs := []string{}
 	if e.Path.IsZero() {
 		cmdArgs = append(cmdArgs, "node")
 	} else {
-		cmdArgs = append(cmdArgs, e.Path.String())
+		p := e.Path.String()
+		cmdArgs = append(cmdArgs, p)
+		labels = append(labels, pubsub.Label{"path", p})
 	}
 	switch e.Action {
 	case "status":
@@ -69,10 +75,16 @@ func (o T) action(e schedule.Entry) error {
 		command.WithEnv(cmdEnv),
 	)
 	o.log.Debug().Msgf("-> exec %s", cmd)
+	o.pubsub.Pub(&msgbus.Exec{Command: cmd.String(), Node: o.localhost, Origin: "scheduler"}, labels...)
+	startTime := time.Now()
 	if err := cmd.Run(); err != nil {
+		duration := time.Now().Sub(startTime)
+		o.pubsub.Pub(&msgbus.ExecFailed{Command: cmd.String(), Duration: duration, ErrS: err.Error(), Node: o.localhost, Origin: "scheduler"}, labels...)
 		o.log.Error().Err(err).Stringer("cmd", cmd).Msg("exec error")
 		return err
 	}
+	duration := time.Now().Sub(startTime)
+	o.pubsub.Pub(&msgbus.ExecSuccess{Command: cmd.String(), Duration: duration, Node: o.localhost, Origin: "scheduler"}, labels...)
 	o.log.Debug().Msgf("<- exec %s", cmd)
 	return nil
 }


### PR DESCRIPTION
# Usage example:

	om node event --filter Exec,path=bar --filter ExecSuccess,path=bar --filter ExecFailed,path=bar --template '{{printf "%s from %s %v %s\n" .kind .data.origin .data.labels .data.command}}'
	# On create object
	Exec from imon map[node:node1 origin:imon path:bar] om bar status -r
	ExecSuccess from imon map[node:node1 origin:imon path:bar] om bar status -r
	
	# On provision object
	Exec from imon map[node:node1 origin:imon path:bar] om bar provision --local --leader --disable-rollback
	ExecSuccess from imon map[node:node1 origin:imon path:bar] om bar provision --local --leader --disable-rollback
	Exec from scheduler map[node:node1 origin:scheduler path:bar] om bar status -r --local
	ExecSuccess from scheduler map[node:node1 origin:scheduler path:bar] om bar status -r --local
	
	# On object switch
	Exec from imon map[node:node1 origin:imon path:bar] om bar stop --local
	ExecSuccess from imon map[node:node1 origin:imon path:bar] om bar stop --local
	
	# On object switch
	Exec from imon map[node:node1 origin:imon path:bar] om bar start --local
	ExecSuccess from imon map[node:node1 origin:imon path:bar] om bar start --local
	
	# On object purge
	Exec from imon map[node:node1 origin:imon path:bar] om bar stop --local
	ExecSuccess from imon map[node:node1 origin:imon path:bar] om bar stop --local
	Exec from imon map[node:node1 origin:imon path:bar] om bar unprovision --local --leader
	ExecSuccess from imon map[node:node1 origin:imon path:bar] om bar unprovision --local --leader
	Exec from imon map[node:node1 origin:imon path:bar] om bar delete
	ExecSuccess from imon map[node:node1 origin:imon path:bar] om bar delete

# yaml view

    kind: ExecSuccess
    id: 2
    at: 2023-08-17T15:20:28.915492345+02:00
    data:
        labels:
            node: node1
           origin: imon
           path: bar
        command: om3 bar status -r
        duration: 27.8764ms
        node: dev1n1
        origin: imon
        title: status

# template example:
    om node event \
        --filter Exec --filter ExecSuccess --filter ExecFailed \
        --template '{{printf "%-35s %s -> %s: %s\n" .at .data.origin .kind .data.command}}'
        
    2023-08-17T15:46:35.96015988+02:00  imon -> Exec: om bar002 stop --local
    2023-08-17T15:46:36.030596814+02:00 imon -> ExecSuccess: om bar002 stop --local
