### PR TITLE
Switch the compliance commands to use native comp objects

### DIFF
--- a/core/rawconfig/node.go
+++ b/core/rawconfig/node.go
@@ -186,6 +186,7 @@ func setDefaults(root string) {
 		nodeViper.SetDefault("paths.etcns", defPathEtcNs)
 		nodeViper.SetDefault("paths.tmp", defPathTmp)
 		nodeViper.SetDefault("paths.doc", defPathDoc)
+		nodeViper.SetDefault("paths.compliance", defPathCompliance)
 		nodeViper.SetDefault("paths.html", defPathHTML)
 		nodeViper.SetDefault("paths.drivers", defPathDrivers)
 	} else {
@@ -204,6 +205,7 @@ func setDefaults(root string) {
 		nodeViper.SetDefault("paths.etcns", filepath.Join(root, "etc", "namespaces"))
 		nodeViper.SetDefault("paths.tmp", filepath.Join(root, "tmp"))
 		nodeViper.SetDefault("paths.doc", filepath.Join(root, "share", "doc"))
+		nodeViper.SetDefault("paths.compliance", filepath.Join(root, "share", "compliance"))
 		nodeViper.SetDefault("paths.html", filepath.Join(root, "share", "html"))
 		nodeViper.SetDefault("paths.drivers", filepath.Join(root, "drivers"))
 	}

--- a/core/rawconfig/paths.go
+++ b/core/rawconfig/paths.go
@@ -24,6 +24,7 @@ var (
 	defPathDoc          = filepath.FromSlash(fmt.Sprintf("/usr/share/doc/%s", Program))
 	defPathHTML         = filepath.FromSlash(fmt.Sprintf("/usr/share/%s/html", Program))
 	defPathDrivers      = filepath.FromSlash(fmt.Sprintf("/usr/libexec/%s", Program))
+	defPathCompliance   = filepath.FromSlash(fmt.Sprintf("/usr/share/%s/compliance", Program))
 )
 
 type (
@@ -47,6 +48,7 @@ type (
 		Doc          string `mapstructure:"doc"`
 		HTML         string `mapstructure:"html"`
 		Drivers      string `mapstructure:"drivers"`
+		Compliance   string `mapstructure:"compliance"`
 	}
 )
 

--- a/util/compliance/run.go
+++ b/util/compliance/run.go
@@ -330,10 +330,10 @@ func (t *Run) getObjectFunc(class string) objectExecFunc {
 }
 
 func (t *Run) objectExec(action Action, v Var, env []string, ma *ModuleAction) int {
-	path := filepath.Join(t.main.varDir, "com.opensvc", v.Class+".py")
+	//path := filepath.Join(t.main.varDir, "com.opensvc", v.Class+".py")
 	cmd := command.New(
-		command.WithName(rawconfig.Paths.Python),
-		command.WithVarArgs(path, v.EnvName(), string(action)),
+		command.WithName(filepath.Join(rawconfig.Paths.Compliance, v.Class)),
+		command.WithVarArgs(v.EnvName(), string(action)),
 		command.WithIgnoredExitCodes(),
 		command.WithEnv(env),
 		command.WithOnStdoutLine(func(s string) {


### PR DESCRIPTION
Define rawconfig.Path.Compliance as /usr/share/opensvc/compliance for packaged deployments and <head>/share/compliance/ for dev deployments.

This directory must host symlinks to the compobj bundle executable.

Example:

$ ls ... /opt/opensvc/share/compliance/

 authkey -> compobj
 compobj
 file -> compobj
 fileinc -> compobj
 fileprop -> compobj
 group -> compobj
 group_membership -> compobj
 nodeconf -> compobj
 package -> compobj
 sudo -> compobj
 svcconf -> compobj
 symlink -> compobj
 sysctl -> compobj
 user -> compobj