### PR TITLE
Add a -i flag to the compobj bundle

### DIFF
--- a/util/compobj/main_test.go
+++ b/util/compobj/main_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type (
@@ -101,7 +102,7 @@ func Test_runAction(t *testing.T) {
 			if tc.expectedErr != "" {
 				wErr = bytes.NewBuffer(bErr)
 			}
-			require.Equal(t, tc.exitCode, mainArgs(tc.args, wOut, wErr))
+			require.Equal(t, tc.exitCode, objMain(tc.args, wOut, wErr))
 
 			if tc.expectedOut != "" {
 				b := make([]byte, len(tc.expectedOut)+1000)


### PR DESCRIPTION
This flag makes it easy to install the compobj symlinks in the target directory.

If the symlink target is different, recreate the symlink.

Example:

$ ./compobj -i /opt/opensvc/share/compliance/
symlink /root/dev/om3/util/compobj/compobj /opt/opensvc/share/compliance/fileprop: already exists symlink /root/dev/om3/util/compobj/compobj /opt/opensvc/share/compliance/group: already exists symlink /root/dev/om3/util/compobj/compobj /opt/opensvc/share/compliance/package: already exists symlink /root/dev/om3/util/compobj/compobj /opt/opensvc/share/compliance/svcconf: already exists symlink /root/dev/om3/util/compobj/compobj /opt/opensvc/share/compliance/symlink: already exists symlink /root/dev/om3/util/compobj/compobj /opt/opensvc/share/compliance/authkey: already exists symlink /root/dev/om3/util/compobj/compobj /opt/opensvc/share/compliance/file: already exists symlink /root/dev/om3/util/compobj/compobj /opt/opensvc/share/compliance/groupmembership: already exists symlink /root/dev/om3/util/compobj/compobj /opt/opensvc/share/compliance/nodeconf: already exists symlink /root/dev/om3/util/compobj/compobj /opt/opensvc/share/compliance/sysctl: already exists symlink /root/dev/om3/util/compobj/compobj /opt/opensvc/share/compliance/user: already exists