### PR TITLE
fix object selection and filtering issues

### DIFF
--- a/core/cluster/cluster.go
+++ b/core/cluster/cluster.go
@@ -69,6 +69,17 @@ func (s *Data) DeepCopy() *Data {
 	return &newStatus
 }
 
+func (s *Data) ObjectPaths() naming.Paths {
+	allPaths := make(naming.Paths, len(s.Cluster.Object))
+	i := 0
+	for p := range s.Cluster.Object {
+		path, _ := naming.ParsePath(p)
+		allPaths[i] = path
+		i++
+	}
+	return allPaths
+}
+
 // WithSelector purges the dataset from objects not matching the selector expression
 func (s *Data) WithSelector(selector string) *Data {
 	if selector == "" {
@@ -76,7 +87,7 @@ func (s *Data) WithSelector(selector string) *Data {
 	}
 	paths, err := objectselector.New(
 		selector,
-		objectselector.WithLocal(true),
+		objectselector.WithInstalled(s.ObjectPaths()),
 	).Expand()
 	if err != nil {
 		return s

--- a/core/objectselector/selection.go
+++ b/core/objectselector/selection.go
@@ -365,12 +365,12 @@ func (t *Selection) localConfigExpand(s string) (*orderedset.OrderedSet, error) 
 
 func (t *Selection) localExactExpand(s string) (*orderedset.OrderedSet, error) {
 	matching := orderedset.NewOrderedSet()
-	path, err := naming.ParsePath(s)
+	paths, err := t.getInstalled()
 	if err != nil {
 		return matching, err
 	}
-	if path.Exists() {
-		matching.Add(path.String())
+	if _, ok := paths.StrMap()[s]; ok {
+		matching.Add(s)
 	}
 	return matching, nil
 }

--- a/daemon/daemonapi/get_daemon_status.go
+++ b/daemon/daemonapi/get_daemon_status.go
@@ -33,9 +33,7 @@ func (a *DaemonAPI) GetDaemonStatus(ctx echo.Context, params api.GetDaemonStatus
 	now := time.Now()
 	subRefreshed.Lock()
 	if now.After(subRefreshed.updated.Add(daemonRefreshInterval)) {
-		if err := a.Daemondata.DaemonRefresh(); err != nil {
-
-		}
+		a.Daemondata.DaemonRefresh()
 		subRefreshed.updated = now
 	}
 	subRefreshed.Unlock()

--- a/daemon/daemondata/daemon_refresh.go
+++ b/daemon/daemondata/daemon_refresh.go
@@ -12,13 +12,13 @@ type (
 
 // DaemonRefresh updates the private dataset of a daemon subsystem
 // (scheduler, dns, ...)
-func (t T) DaemonRefresh() error {
-	err := make(chan error, 1)
+func (t T) DaemonRefresh() {
+	errC := make(chan error, 1)
 	op := opDaemonRefresh{
-		errC: err,
+		errC: errC,
 	}
 	t.cmdC <- op
-	return <-err
+	<-errC
 }
 
 func (o opDaemonRefresh) call(ctx context.Context, d *data) error {


### PR DESCRIPTION
"om plop* mon" displayed only the objects with a local instance.
"om plop mon" displayed no match when plop has no local instance.
