### PR TITLE
Hide the "o[mx] node version" commands

### DIFF
--- a/core/om/factory.go
+++ b/core/om/factory.go
@@ -19,9 +19,8 @@ var (
 
 func newCmdAll() *cobra.Command {
 	return &cobra.Command{
-		Hidden: false,
-		Use:    "all",
-		Short:  "manage a mix of objects, tentatively exposing all commands",
+		Use:   "all",
+		Short: "manage a mix of objects, tentatively exposing all commands",
 	}
 }
 
@@ -1460,8 +1459,9 @@ func newCmdNodeUnset() *cobra.Command {
 
 func newCmdNodeVersion() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "display agent version",
+		Use:    "version",
+		Short:  "display agent version",
+		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			commands.CmdNodeVersion()
 		},

--- a/core/om/root.go
+++ b/core/om/root.go
@@ -36,6 +36,7 @@ var (
 	nodeFlag       string
 	foregroundFlag bool
 	callerFlag     bool
+	versionFlag    bool
 
 	//go:embed bash_completion.sh
 	bashCompletionFunction string
@@ -48,6 +49,7 @@ var (
 		SilenceErrors:          false,
 		ValidArgsFunction:      validArgs,
 		BashCompletionFunction: bashCompletionFunction,
+		Version:                version.Version(),
 	}
 )
 

--- a/core/ox/factory.go
+++ b/core/ox/factory.go
@@ -18,9 +18,8 @@ var (
 
 func newCmdAll() *cobra.Command {
 	return &cobra.Command{
-		Hidden: false,
-		Use:    "all",
-		Short:  "manage a mix of objects, tentatively exposing all commands",
+		Use:   "all",
+		Short: "manage a mix of objects, tentatively exposing all commands",
 	}
 }
 
@@ -1561,8 +1560,9 @@ func newCmdNodeUnset() *cobra.Command {
 
 func newCmdNodeVersion() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "display agent version",
+		Use:    "version",
+		Short:  "display agent version",
+		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			commands.CmdNodeVersion()
 		},

--- a/core/ox/root.go
+++ b/core/ox/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opensvc/om3/core/env"
 	"github.com/opensvc/om3/core/naming"
 	"github.com/opensvc/om3/core/rawconfig"
+	"github.com/opensvc/om3/util/version"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
@@ -37,6 +38,7 @@ var (
 		SilenceErrors:          false,
 		ValidArgsFunction:      validArgs,
 		BashCompletionFunction: bashCompletionFunction,
+		Version:                version.Version(),
 	}
 )
 


### PR DESCRIPTION
And support:

$ bin/ox -v
ox version v3.0.0-alpha10-443-gc0a6c57d

$ bin/om -v
om version v3.0.0-alpha10-443-gc0a6c57d