### PR TITLE
Add the "running" imon state

### DIFF
--- a/core/actioncontext/props.go
+++ b/core/actioncontext/props.go
@@ -201,6 +201,7 @@ var (
 	}
 	Run = Properties{
 		Name:            "run",
+		Progress:        "running",
 		Local:           true,
 		Kinds:           naming.NewKinds(naming.KindSvc, naming.KindVol),
 		TimeoutKeywords: []string{"run_timeout", "timeout"},

--- a/core/instance/monitor.go
+++ b/core/instance/monitor.go
@@ -107,6 +107,7 @@ const (
 	MonitorStateProvisionFailed
 	MonitorStatePurgeFailed
 	MonitorStateReady
+	MonitorStateRunning
 	MonitorStateShutdownFailed
 	MonitorStateShutdown
 	MonitorStateShutting
@@ -169,6 +170,7 @@ var (
 		MonitorStateProvisionFailed:   "provision failed",
 		MonitorStatePurgeFailed:       "purge failed",
 		MonitorStateReady:             "ready",
+		MonitorStateRunning:           "running",
 		MonitorStateShutdown:          "shutdown",
 		MonitorStateShutdownFailed:    "shutdown failed",
 		MonitorStateShutting:          "shutting",
@@ -207,6 +209,7 @@ var (
 		"provision failed":   MonitorStateProvisionFailed,
 		"purge failed":       MonitorStatePurgeFailed,
 		"ready":              MonitorStateReady,
+		"running":            MonitorStateRunning,
 		"shutdown":           MonitorStateShutdown,
 		"shutdown failed":    MonitorStateShutdownFailed,
 		"shutting":           MonitorStateShutting,

--- a/core/object/core_action.go
+++ b/core/object/core_action.go
@@ -175,7 +175,7 @@ func (t *actor) announceProgress(ctx context.Context, progress string) error {
 		t.log.Errorf("announce %s state: %s", progress, err)
 		return err
 	case resp.StatusCode != http.StatusOK:
-		err := fmt.Errorf("unexpected post object progress status %s", resp.Status)
+		err := fmt.Errorf("unexpected post instance progress request status: %s", resp.Status)
 		t.log.Errorf("announce %s state: %s", progress, err)
 		return err
 	}

--- a/daemon/imon/orchestration_purged.go
+++ b/daemon/imon/orchestration_purged.go
@@ -23,6 +23,7 @@ func (t *Manager) orchestratePurged() {
 		t.purgedFromWaitNonLeader()
 	case instance.MonitorStateUnprovisioning,
 		instance.MonitorStateDeleting,
+		instance.MonitorStateRunning,
 		instance.MonitorStateStopping:
 	default:
 		t.log.Warnf("orchestratePurged has no solution from state %s", t.state.State)

--- a/daemon/imon/orchestration_started.go
+++ b/daemon/imon/orchestration_started.go
@@ -29,6 +29,7 @@ func (t *Manager) orchestrateStarted() {
 	case instance.MonitorStateStopping:
 		t.startedFromAny()
 	case instance.MonitorStateThawing:
+	case instance.MonitorStateRunning:
 	case instance.MonitorStateWaitParents:
 		t.setWaitParents()
 	default:

--- a/daemon/imon/orchestration_stopped.go
+++ b/daemon/imon/orchestration_stopped.go
@@ -25,6 +25,7 @@ func (t *Manager) freezeStop() {
 		t.stoppedFromReady()
 	case instance.MonitorStateFreezing:
 		// wait for the freeze exec to end
+	case instance.MonitorStateRunning:
 	case instance.MonitorStateStopping:
 		// avoid multiple concurrent stop execs
 	case instance.MonitorStateStopFailed:


### PR DESCRIPTION
The run instance action now announces the "running" imon state via API.

The orchestrations now consider the "running" state has a blocker for start, stop, unprovision, provision, purge.