### PR TITLE
Return an explicit error instead of silently droping the "priority" kop

### DIFF
--- a/core/object/core_keywords.go
+++ b/core/object/core_keywords.go
@@ -2,12 +2,14 @@ package object
 
 import (
 	"embed"
+	"fmt"
 
 	"github.com/opensvc/om3/core/driver"
 	"github.com/opensvc/om3/core/keyop"
 	"github.com/opensvc/om3/core/keywords"
 	"github.com/opensvc/om3/core/naming"
 	"github.com/opensvc/om3/core/placement"
+	"github.com/opensvc/om3/core/priority"
 	"github.com/opensvc/om3/core/rawconfig"
 	"github.com/opensvc/om3/core/resource"
 	"github.com/opensvc/om3/core/resourceid"
@@ -361,7 +363,7 @@ var keywordStore = keywords.Store{
 	{
 		Section:   "DEFAULT",
 		Option:    "priority",
-		Default:   "50",
+		Default:   fmt.Sprint(priority.Default),
 		Scopable:  false,
 		Inherit:   keywords.InheritHead,
 		Converter: converters.Int,

--- a/daemon/daemonhelper/main.go
+++ b/daemon/daemonhelper/main.go
@@ -18,7 +18,9 @@ import (
 	"github.com/opensvc/om3/core/rawconfig"
 	"github.com/opensvc/om3/daemon/daemonctx"
 	"github.com/opensvc/om3/daemon/daemondata"
+	"github.com/opensvc/om3/daemon/daemonenv"
 	"github.com/opensvc/om3/daemon/hbcache"
+	"github.com/opensvc/om3/daemon/runner"
 	"github.com/opensvc/om3/testhelper"
 	"github.com/opensvc/om3/util/hostname"
 	"github.com/opensvc/om3/util/pubsub"
@@ -67,6 +69,11 @@ func Setup(t *testing.T, env *testhelper.Env) *D {
 	dataCmd, dataMsgRecvQ, dataCmdCancel := daemondata.Start(ctx, drainDuration, pubsub.WithQueueSize(100))
 	ctx = daemondata.ContextWithBus(ctx, dataCmd)
 	ctx = daemonctx.WithHBRecvMsgQ(ctx, dataMsgRecvQ)
+
+	qsSmall := pubsub.WithQueueSize(daemonenv.SubQSSmall)
+	testRunner := runner.NewDefault(qsSmall)
+	testRunner.SetMaxRunning(20)
+	testRunner.Start(ctx)
 
 	cancelD := func() {
 		cancel()

--- a/daemon/daemonhelper/main.go
+++ b/daemon/daemonhelper/main.go
@@ -73,6 +73,7 @@ func Setup(t *testing.T, env *testhelper.Env) *D {
 	qsSmall := pubsub.WithQueueSize(daemonenv.SubQSSmall)
 	testRunner := runner.NewDefault(qsSmall)
 	testRunner.SetMaxRunning(20)
+	testRunner.SetInterval(2 * time.Millisecond)
 	testRunner.Start(ctx)
 
 	cancelD := func() {

--- a/daemon/runner/main.go
+++ b/daemon/runner/main.go
@@ -77,11 +77,15 @@ func (t *T) run() {
 }
 
 func (t *T) do(ctx context.Context) {
-	defer t.wg.Done()
 	ticker := time.NewTicker(t.interval)
-	defer ticker.Stop()
 	sub := t.startSubscriptions()
-	defer sub.Stop()
+	defer func() {
+		sub.Stop()
+		ticker.Stop()
+		t.ctx = nil
+		t.cancel = nil
+		t.wg.Done()
+	}()
 	for {
 		select {
 		case ev := <-sub.C:
@@ -101,10 +105,18 @@ func (t *T) do(ctx context.Context) {
 	}
 }
 
-func NewDefault(subQS pubsub.QueueSizer) *T {
-	if def == nil {
-		def = New(subQS)
+func SetDefault(t *T) {
+	if def != nil {
+		panic("a default runner is already installed")
 	}
+	def = t
+}
+
+func NewDefault(subQS pubsub.QueueSizer) *T {
+	if def != nil {
+		return def
+	}
+	def = New(subQS)
 	return def
 }
 
@@ -127,6 +139,9 @@ func (t *T) Stop() error {
 }
 
 func (t *T) Start(ctx context.Context) error {
+	if t.ctx != nil {
+		return nil
+	}
 	t.ctx, t.cancel = context.WithCancel(ctx)
 	t.wg.Add(1)
 	go t.do(ctx)
@@ -147,8 +162,12 @@ func (t *T) SetMaxRunning(n int) {
 	t.maxRunning = n
 }
 
-func Start(ctx context.Context) {
-	def.Start(ctx)
+func Stop() error {
+	return def.Stop()
+}
+
+func Start(ctx context.Context) error {
+	return def.Start(ctx)
 }
 
 func Run(p priority.T, f func() error) error {

--- a/daemon/runner/main.go
+++ b/daemon/runner/main.go
@@ -162,6 +162,10 @@ func (t *T) SetMaxRunning(n int) {
 	t.maxRunning = n
 }
 
+func (t *T) SetInterval(d time.Duration) {
+	t.interval = d
+}
+
 func Stop() error {
 	return def.Stop()
 }

--- a/daemon/runner/main.go
+++ b/daemon/runner/main.go
@@ -144,7 +144,7 @@ func (t *T) Start(ctx context.Context) error {
 	}
 	t.ctx, t.cancel = context.WithCancel(ctx)
 	t.wg.Add(1)
-	go t.do(ctx)
+	go t.do(t.ctx)
 	return nil
 }
 


### PR DESCRIPTION
Example:

$ curl  -o- -k -X POST -u me:pw -H "Content-Type: application/json" "https://127.0.0.1:1215/object/path/test/svc/svc2/config/update?set=priority=2" {"detail":"","status":401,"title":"Not allowed to set priority (the root or prioritizer grant is required)"}