### PR TITLE
Fix flex_{min,max,target} values

### DIFF
--- a/core/object/core_keywords.go
+++ b/core/object/core_keywords.go
@@ -330,7 +330,7 @@ var keywordStore = keywords.Store{
 	},
 	{
 		Converter:   converters.Int,
-		Default:     "1",
+		Default:     "{flex_min}",
 		DefaultText: keywords.NewText(fs, "text/kw/core/flex_target.default"),
 		Depends:     keyop.ParseList("topology=flex"),
 		Inherit:     keywords.InheritHead,


### PR DESCRIPTION
* default flex_target kw value changed to {flex_min}

* icfg flex_min is evaluated first and must be >=1 on svc or >=0 on vol, and must be <= n_instances whatever the kind

* icfg flex_max is evaluated next and must be >= flex_min and <= n_instances

* icfg flex_target is evaluated last and must be >= flex_min and <= flex_max