### PR TITLE
More ox tui command access and filtering from the command line

### DIFF
--- a/core/object/core_action.go
+++ b/core/object/core_action.go
@@ -84,21 +84,21 @@ func (t *actor) preAction(ctx context.Context) error {
 
 func (t *actor) needRollback(ctx context.Context) bool {
 	if actionrollback.Len(ctx) == 0 {
-		t.Log().Debugf("skip rollback: Empty stack")
+		t.Log().Debugf("skip rollback: empty stack")
 		return false
 	}
 	action := actioncontext.Props(ctx)
 	if !action.Rollback {
-		t.Log().Debugf("skip rollback: Not demanded by the %s action", action.Name)
+		t.Log().Debugf("skip rollback: not demanded by the %s action", action.Name)
 		return false
 	}
 	if actioncontext.IsRollbackDisabled(ctx) {
-		t.Log().Debugf("skip rollback: Disabled via the command flag")
+		t.Log().Debugf("skip rollback: disabled via the command flag")
 		return false
 	}
 	k := key.Parse("rollback")
 	if !t.Config().GetBool(k) {
-		t.Log().Debugf("skip rollback: Disabled via configuration keyword")
+		t.Log().Debugf("skip rollback: disabled via configuration keyword")
 		return false
 	}
 	return true
@@ -170,7 +170,7 @@ func (t *actor) announceProgress(ctx context.Context, progress string) error {
 	})
 	switch {
 	case errors.Is(err, os.ErrNotExist):
-		t.log.Debugf("skip announce progress: The daemon is not running")
+		t.log.Debugf("skip announce progress: the daemon is not running")
 		return nil
 	case err != nil:
 		t.log.Errorf("announce %s state: %s", progress, err)
@@ -470,15 +470,15 @@ func (t *actor) mayFreeze(ctx context.Context) error {
 		return nil
 	}
 	if !resourceselector.FromContext(ctx, nil).IsZero() {
-		t.log.Debugf("skip freeze: Resource selection")
+		t.log.Debugf("skip freeze: resource selection")
 		return nil
 	}
 	if !t.orchestrateWantsFreeze() {
-		t.log.Debugf("skip freeze: Orchestrate value")
+		t.log.Debugf("skip freeze: orchestrate value")
 		return nil
 	}
 	if env.HasDaemonMonitorOrigin() {
-		t.log.Debugf("skip freeze: Action has daemon origin")
+		t.log.Debugf("skip freeze: action has daemon origin")
 		return nil
 	}
 	return t.Freeze(ctx)

--- a/core/om/flags.go
+++ b/core/om/flags.go
@@ -52,7 +52,9 @@ func addFlagsGlobalServer(flagSet *pflag.FlagSet, p *commands.OptsGlobal) {
 }
 
 func addFlagsGlobalObjectSelector(flagSet *pflag.FlagSet, p *commands.OptsGlobal) {
-	flagSet.StringVarP(&p.ObjectSelector, "service", "s", "", "Execute on a list of objects.")
+	flagSet.StringVarP(&p.ObjectSelector, "service", "", "", "Execute on a list of objects.")
+	flagSet.StringVarP(&p.ObjectSelector, "selector", "s", "", "Execute on a list of objects.")
+	flagSet.MarkHidden("service")
 }
 
 func addFlagsGlobal(flagSet *pflag.FlagSet, p *commands.OptsGlobal) {
@@ -238,11 +240,16 @@ func addFlagNoLock(flagSet *pflag.FlagSet, p *bool) {
 }
 
 func addFlagObject(flagSet *pflag.FlagSet, p *string) {
-	flagSet.StringVarP(p, "service", "s", "", "Execute on a list of objects.")
+	flagSet.StringVarP(p, "service", "", "", "Execute on a list of objects.")
+	flagSet.StringVarP(p, "selector", "s", "", "Execute on a list of objects.")
+	flagSet.MarkHidden("service")
+
 }
 
 func addFlagObjectSelector(flagSet *pflag.FlagSet, p *string) {
-	flagSet.StringVarP(p, "service", "s", "", "An object selector expression. `**/s[12]+!*/vol/*`.")
+	flagSet.StringVarP(p, "service", "", "", "An object selector expression. `**/s[12]+!*/vol/*`.")
+	flagSet.StringVarP(p, "selector", "s", "", "An object selector expression. `**/s[12]+!*/vol/*`.")
+	flagSet.MarkHidden("service")
 }
 
 func addFlagPoolName(flagSet *pflag.FlagSet, p *string) {

--- a/core/ox/all.go
+++ b/core/ox/all.go
@@ -71,6 +71,7 @@ func init() {
 		newCmdObjectUnprovision(kind),
 		newCmdObjectUnset(kind),
 		newCmdObjectUpdate(kind),
+		newCmdTUI(kind),
 	)
 	cmdObjectInstance.AddCommand(
 		newCmdObjectInstanceLs(kind),

--- a/core/ox/ccfg.go
+++ b/core/ox/ccfg.go
@@ -34,6 +34,7 @@ func init() {
 		newCmdObjectStatus(kind),
 		newCmdObjectUnset(kind),
 		newCmdObjectUpdate(kind),
+		newCmdTUI(kind),
 	)
 	cmdObjectEdit.AddCommand(
 		newCmdObjectEditConfig(kind),

--- a/core/ox/cfg.go
+++ b/core/ox/cfg.go
@@ -38,6 +38,7 @@ func init() {
 		newCmdObjectStatus(kind),
 		newCmdObjectUnset(kind),
 		newCmdObjectUpdate(kind),
+		newCmdTUI(kind),
 	)
 	cmdObjectEdit.AddCommand(
 		newCmdObjectEditConfig(kind),

--- a/core/ox/factory.go
+++ b/core/ox/factory.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/opensvc/om3/core/monitor"
 	commands "github.com/opensvc/om3/core/oxcmd"
+	"github.com/opensvc/om3/core/tui"
 )
 
 var (
@@ -3069,5 +3070,18 @@ func newCmdSecPKCS(kind string) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	addFlagsGlobal(flags, &options.OptsGlobal)
+	return cmd
+}
+
+func newCmdTUI(kind string) *cobra.Command {
+	var options tui.Options
+	cmd := &cobra.Command{
+		Use:   "tui",
+		Short: "interactive terminal user interface.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			options.Selector = mergeSelector("", kind, "")
+			return tui.Run(&options)
+		},
+	}
 	return cmd
 }

--- a/core/ox/flags.go
+++ b/core/ox/flags.go
@@ -29,7 +29,7 @@ func addFlagsGlobal(flagSet *pflag.FlagSet, p *commands.OptsGlobal) {
 	flagSet.StringVar(&p.Color, "color", "auto", "Output colorization yes|no|auto.")
 	flagSet.StringVarP(&p.Output, "output", "o", "auto", "Output format json|flat|auto|tab=<header>:<jsonpath>,...")
 	flagSet.StringVar(&p.Server, "server", "", "URI of the opensvc api server.")
-	flagSet.StringVarP(&p.ObjectSelector, "service", "s", "", "Execute on a list of objects.")
+	flagSet.StringVarP(&p.ObjectSelector, "selector", "s", "", "Execute on a list of objects.")
 
 }
 
@@ -198,11 +198,11 @@ func addFlagNoLock(flagSet *pflag.FlagSet, p *bool) {
 }
 
 func addFlagObject(flagSet *pflag.FlagSet, p *string) {
-	flagSet.StringVarP(p, "service", "s", "", "Execute on a list of objects.")
+	flagSet.StringVarP(p, "selector", "s", "", "Execute on a list of objects.")
 }
 
 func addFlagObjectSelector(flagSet *pflag.FlagSet, p *string) {
-	flagSet.StringVarP(p, "service", "s", "", "An object selector expression. `**/s[12]+!*/vol/*`.")
+	flagSet.StringVarP(p, "selector", "s", "", "An object selector expression. `**/s[12]+!*/vol/*`.")
 }
 
 func addFlagPoolName(flagSet *pflag.FlagSet, p *string) {

--- a/core/ox/sec.go
+++ b/core/ox/sec.go
@@ -40,6 +40,7 @@ func init() {
 		newCmdObjectUpdate(kind),
 		newCmdSecGenCert(kind),
 		newCmdSecPKCS(kind),
+		newCmdTUI(kind),
 	)
 	cmdObjectEdit.AddCommand(
 		newCmdObjectEditConfig(kind),

--- a/core/ox/svc.go
+++ b/core/ox/svc.go
@@ -69,6 +69,7 @@ func init() {
 		newCmdObjectUnprovision(kind),
 		newCmdObjectUnset(kind),
 		newCmdObjectUpdate(kind),
+		newCmdTUI(kind),
 	)
 	cmdObjectEdit.AddCommand(
 		newCmdObjectEditConfig(kind),

--- a/core/ox/usr.go
+++ b/core/ox/usr.go
@@ -39,6 +39,7 @@ func init() {
 		newCmdObjectUpdate(kind),
 		newCmdSecGenCert(kind),
 		newCmdSecPKCS(kind),
+		newCmdTUI(kind),
 	)
 	cmdObjectEdit.AddCommand(
 		newCmdObjectEditConfig(kind),

--- a/core/ox/vol.go
+++ b/core/ox/vol.go
@@ -60,6 +60,7 @@ func init() {
 		newCmdObjectUnprovision(kind),
 		newCmdObjectUnset(kind),
 		newCmdObjectUpdate(kind),
+		newCmdTUI(kind),
 	)
 	cmdObjectCollector.AddCommand(
 		cmdObjectCollectorTag,

--- a/core/tui/main.go
+++ b/core/tui/main.go
@@ -110,12 +110,18 @@ var (
 	colorHighlight = tcell.ColorWhite
 )
 
-func Run(args []string) error {
+type Options struct {
+	Selector string
+}
+
+func Run(options *Options) error {
 	app := NewApp()
-	if len(args) > 0 {
-		app.Frame.Selector = args[1]
+	if options != nil {
+		if options.Selector != "" {
+			app.Frame.Selector = options.Selector
+		}
 	}
-	return NewApp().Run()
+	return app.Run()
 }
 
 func (t viewStack) String() string {
@@ -143,7 +149,6 @@ func (t *App) updateHead() {
 		if t.client != nil {
 			endpoint = t.client.Hostname()
 		}
-		s := t.user + "@" + endpoint
 		switch {
 		case t.user == "" && endpoint == "":
 			return ""
@@ -152,7 +157,6 @@ func (t *App) updateHead() {
 		default:
 			return fmt.Sprintf("%s@%s", t.user, endpoint)
 		}
-		return s
 	}
 	title := box.GetTitle()
 	t.head.SetCell(0, 0, tview.NewTableCell(conn()).SetBackgroundColor(colorHead3))
@@ -1620,8 +1624,8 @@ func (t *App) skipIfInstanceNotUpdated() bool {
 		t.errorf("node config disappeared")
 		return true
 	} else if instanceData, ok := nodeData.Instance[t.viewPath.String()]; !ok {
-		return true
 		t.errorf("instance config disappeared")
+		return true
 	} else if instanceData.Config.UpdatedAt.After(t.lastUpdatedAt) {
 		t.lastUpdatedAt = instanceData.Config.UpdatedAt
 		return false


### PR DESCRIPTION
With this patch, the tui can be launched via:

* display only svc
  * ox
  * ox tui
  * ox svc tui

* display only <kind> objects:
  * ox <kind> tui
  * ox '*/<kind>/*'
  * ox '*/<kind>/*' tui

* display only objects matching <selector>:
  * ox <selector>
  * ox <selector> tui