### PR TITLE
Fixes for the provision orchestration

### DIFF
--- a/core/tui/main.go
+++ b/core/tui/main.go
@@ -1626,10 +1626,10 @@ func (t *App) skipIfInstanceNotUpdated() bool {
 	} else if instanceData, ok := nodeData.Instance[t.viewPath.String()]; !ok {
 		t.errorf("instance config disappeared")
 		return true
-	} else if instanceData.Config.UpdatedAt.After(t.lastUpdatedAt) {
+	} else if instanceData.Config != nil && instanceData.Config.UpdatedAt.After(t.lastUpdatedAt) {
 		t.lastUpdatedAt = instanceData.Config.UpdatedAt
 		return false
-	} else if instanceData.Status.UpdatedAt.After(t.lastUpdatedAt) {
+	} else if instanceData.Status != nil && instanceData.Status.UpdatedAt.After(t.lastUpdatedAt) {
 		t.lastUpdatedAt = instanceData.Status.UpdatedAt
 		return false
 	}

--- a/daemon/imon/orchestration_provisioned.go
+++ b/daemon/imon/orchestration_provisioned.go
@@ -64,9 +64,17 @@ func (t *Manager) provisionedFromWaitLeader() {
 
 func (t *Manager) provisionedClearIfReached() bool {
 	reached := func(msg string) bool {
+		if t.instStatus[t.localhost].IsFrozen() {
+			t.doUnfreeze()
+		}
 		t.log.Infof(msg)
 		t.doneAndIdle()
 		t.updateIfChange()
+		return true
+	}
+	if t.isAllState(instance.MonitorStateProvisionFailed) {
+		t.loggerWithState().Infof("all instances provision failed -> set done")
+		t.done()
 		return true
 	}
 	if t.instStatus[t.localhost].Provisioned.IsOneOf(provisioned.True, provisioned.NotApplicable) {

--- a/daemon/imon/orchestration_started.go
+++ b/daemon/imon/orchestration_started.go
@@ -168,7 +168,7 @@ func (t *Manager) startedFromStartFailed() {
 	if t.state.OrchestrationIsDone {
 		return
 	}
-	if t.isAllStartFailed() {
+	if t.isAllState(instance.MonitorStateStartFailed) {
 		t.loggerWithState().Infof("all instances start failed -> set done")
 		t.done()
 		return
@@ -189,9 +189,9 @@ func (t *Manager) isAnyPeerState(states ...instance.MonitorState) (string, insta
 	return "", instance.MonitorStateInit
 }
 
-func (t *Manager) isAllStartFailed() bool {
+func (t *Manager) isAllState(state instance.MonitorState) bool {
 	for _, instMon := range t.AllInstanceMonitors() {
-		if instMon.State != instance.MonitorStateStartFailed {
+		if instMon.State != state {
 			return false
 		}
 	}


### PR DESCRIPTION
* clear the global expect if all instances are "provision failed"

* unfreeze the instance if already provisioned and frozen