### PR TITLE
Introduce "stopped" state transition in orchestration stop process

### DIFF
--- a/daemon/imon/orchestration_ha.go
+++ b/daemon/imon/orchestration_ha.go
@@ -54,6 +54,15 @@ func (t *Manager) orchestrateHAStart() {
 			t.transitionTo(instance.MonitorStateIdle)
 		}
 		return
+	case instance.MonitorStateStopped:
+		// stopped means the action stop has been done. This state is a
+		// waiter step to take time to disable the local expect started.
+		if t.state.LocalExpect == instance.MonitorLocalExpectStarted {
+			t.log.Infof("instance is now stopped, disable resource restart and monitor action")
+			t.state.LocalExpect = instance.MonitorLocalExpectNone
+		}
+		t.transitionTo(instance.MonitorStateIdle)
+		return
 	}
 	if v, reason := t.isStartable(); !v {
 		if t.pendingCancel != nil && t.state.State == instance.MonitorStateReady {

--- a/daemon/imon/orchestration_stopped.go
+++ b/daemon/imon/orchestration_stopped.go
@@ -26,6 +26,8 @@ func (t *Manager) freezeStop() {
 	case instance.MonitorStateFreezing:
 		// wait for the freeze exec to end
 	case instance.MonitorStateRunning:
+	case instance.MonitorStateStopped:
+		t.transitionTo(instance.MonitorStateIdle)
 	case instance.MonitorStateStopping:
 		// avoid multiple concurrent stop execs
 	case instance.MonitorStateStopFailed:
@@ -48,6 +50,8 @@ func (t *Manager) stop() {
 		t.doStop()
 	case instance.MonitorStateReady:
 		t.stoppedFromReady()
+	case instance.MonitorStateStopped:
+		t.transitionTo(instance.MonitorStateIdle)
 	case instance.MonitorStateFrozen:
 		// honor the frozen state
 	case instance.MonitorStateFreezing:
@@ -95,7 +99,7 @@ func (t *Manager) doStop() {
 		return
 	}
 	t.createPendingWithDuration(stopDuration)
-	t.queueAction(t.crmStop, instance.MonitorStateStopping, instance.MonitorStateIdle, instance.MonitorStateStopFailed)
+	t.queueAction(t.crmStop, instance.MonitorStateStopping, instance.MonitorStateStopped, instance.MonitorStateStopFailed)
 }
 
 func (t *Manager) stoppedFromReady() {


### PR DESCRIPTION
<details>
<summary>Details</summary>

- Added a "stopped" transition state in orchestration functions
- Updated flow: stopping -> stopped -> idle
- Utilized "stopped" state in orchestrateHAStart function
- Changed local expectation from started to none

</details>