### PR TITLE
Introduce "stopped" state in orchestration stop process

### DIFF
--- a/core/instance/monitor.go
+++ b/core/instance/monitor.go
@@ -41,7 +41,8 @@ type (
 		OrchestrationID uuid.UUID `json:"orchestration_id"`
 
 		// OrchestrationIsDone is set by the orchestration when it decides the instance state has reached its target.
-		// A orchestration is cleaned up when all instance monitors have OrchestrationIsDone set.
+		// It is used to clear orchestration and orchestration id up when all instance monitors have
+		// OrchestrationIsDone set.
 		OrchestrationIsDone bool `json:"orchestration_is_done"`
 
 		SessionID               uuid.UUID        `json:"session_id"`

--- a/daemon/imon/converge_global_expect.go
+++ b/daemon/imon/converge_global_expect.go
@@ -37,6 +37,10 @@ func (t *Manager) convergeGlobalExpectFromRemote() {
 		}
 		t.log.Infof("fetch global expect from node %s -> %s orchestration id %s updated at %s",
 			mostRecentNode, strVal, t.state.OrchestrationID, mostRecentUpdated)
+		if t.state.OrchestrationIsDone {
+			t.state.OrchestrationIsDone = false
+			t.log.Debugf("reset previous orchestration is done on fetched global expect")
+		}
 		t.log = t.newLogger(t.state.OrchestrationID)
 	}
 }

--- a/daemon/imon/main_cmd.go
+++ b/daemon/imon/main_cmd.go
@@ -612,10 +612,12 @@ func (t *Manager) onSetInstanceMonitor(c *msgbus.SetInstanceMonitor) {
 		t.onChange()
 	} else {
 		t.pubsubBus.Pub(&msgbus.ObjectOrchestrationRefused{
-			Node:   t.localhost,
-			Path:   t.path,
-			ID:     c.Value.CandidateOrchestrationID.String(),
-			Reason: fmt.Sprintf("set instance monitor request => no changes: %v", c.Value),
+			Node:                t.localhost,
+			Path:                t.path,
+			ID:                  c.Value.CandidateOrchestrationID.String(),
+			Reason:              fmt.Sprintf("set instance monitor request => no changes: %v", c.Value),
+			GlobalExpect:        c.Value.GlobalExpect,
+			GlobalExpectOptions: c.Value.GlobalExpectOptions,
 		},
 			t.labelPath,
 			t.labelLocalhost,

--- a/daemon/imon/orchestration.go
+++ b/daemon/imon/orchestration.go
@@ -147,6 +147,10 @@ func (t *Manager) setWaitChildren() bool {
 // endOrchestration is called when orchestration has been reached on all nodes
 func (t *Manager) endOrchestration() {
 	t.change = true
+	globalExpect := t.state.GlobalExpect
+	globalExpectUpdatedAt := t.state.GlobalExpectUpdatedAt
+	globalExpectOptions := t.state.GlobalExpectOptions
+
 	t.state.GlobalExpect = instance.MonitorGlobalExpectNone
 	t.state.GlobalExpectOptions = nil
 	t.state.OrchestrationIsDone = false
@@ -155,9 +159,12 @@ func (t *Manager) endOrchestration() {
 	t.updateIfChange()
 	if t.acceptedOrchestrationID != uuid.Nil {
 		t.pubsubBus.Pub(&msgbus.ObjectOrchestrationEnd{
-			Node: t.localhost,
-			Path: t.path,
-			ID:   t.acceptedOrchestrationID.String(),
+			Node:                  t.localhost,
+			Path:                  t.path,
+			ID:                    t.acceptedOrchestrationID.String(),
+			GlobalExpect:          globalExpect,
+			GlobalExpectUpdatedAt: globalExpectUpdatedAt,
+			GlobalExpectOptions:   globalExpectOptions,
 		},
 			t.labelPath,
 			t.labelLocalhost,

--- a/daemon/imon/orchestration.go
+++ b/daemon/imon/orchestration.go
@@ -171,7 +171,10 @@ func (t *Manager) endOrchestration() {
 // sets the state to idle.
 func (t *Manager) doneAndIdle() {
 	t.done()
-	t.state.State = instance.MonitorStateIdle
+	if t.state.State != instance.MonitorStateIdle {
+		t.change = true
+		t.state.State = instance.MonitorStateIdle
+	}
 }
 
 // done() sets marks the orchestration as done on the local instance.
@@ -179,9 +182,9 @@ func (t *Manager) doneAndIdle() {
 // after the orchestration is ended.
 // OrchestrationIsDone is set to true when orchestrationID is set.
 func (t *Manager) done() {
-	t.change = true
 	if t.state.OrchestrationID != uuid.Nil && !t.state.OrchestrationIsDone {
 		t.log.Debugf("set OrchestrationIsDone -> true for OrchestrationID %s", t.state.OrchestrationID)
+		t.change = true
 		t.state.OrchestrationIsDone = true
 	} else if !t.state.OrchestrationIsDone {
 		t.log.Debugf("skip change OrchestrationIsDone (OrchestrationID is nil)")

--- a/daemon/imon/orchestration.go
+++ b/daemon/imon/orchestration.go
@@ -177,9 +177,15 @@ func (t *Manager) doneAndIdle() {
 // done() sets marks the orchestration as done on the local instance.
 // It can be used instead of doneAndIdle() when we want a state to linger
 // after the orchestration is ended.
+// OrchestrationIsDone is set to true when orchestrationID is set.
 func (t *Manager) done() {
 	t.change = true
-	t.state.OrchestrationIsDone = true
+	if t.state.OrchestrationID != uuid.Nil && !t.state.OrchestrationIsDone {
+		t.log.Debugf("set OrchestrationIsDone -> true for OrchestrationID %s", t.state.OrchestrationID)
+		t.state.OrchestrationIsDone = true
+	} else if !t.state.OrchestrationIsDone {
+		t.log.Debugf("skip change OrchestrationIsDone (OrchestrationID is nil)")
+	}
 }
 
 func (t *Manager) orchestrationIsAllDone() bool {

--- a/daemon/imon/orchestration_ha.go
+++ b/daemon/imon/orchestration_ha.go
@@ -54,6 +54,15 @@ func (t *Manager) orchestrateHAStart() {
 			t.transitionTo(instance.MonitorStateIdle)
 		}
 		return
+	case instance.MonitorStateStopped:
+		// stopped means the action stop has been done. This state is a
+		// waiter step to take time to disable the local expect started.
+		if t.state.LocalExpect == instance.MonitorLocalExpectStarted {
+			t.log.Infof("instance is now stopped, disable resource restart and monitor action")
+			t.state.LocalExpect = instance.MonitorLocalExpectNone
+		}
+		t.transitionTo(instance.MonitorStateIdle)
+		return
 	}
 	if v, reason := t.isStartable(); !v {
 		if t.pendingCancel != nil && t.state.State == instance.MonitorStateReady {

--- a/daemon/imon/orchestration_resource_restart.go
+++ b/daemon/imon/orchestration_resource_restart.go
@@ -49,6 +49,9 @@ func (t *Manager) doMonitorAction(rid string, stage int) {
 	case instance.MonitorActionFreezeStop:
 	case instance.MonitorActionReboot:
 	case instance.MonitorActionSwitch:
+	case instance.MonitorActionNone:
+		t.log.Infof("skip monitor action: not configured")
+		return
 	default:
 		t.log.Errorf("skip monitor action: not supported: %s", monitorAction)
 		return

--- a/daemon/imon/orchestration_stopped.go
+++ b/daemon/imon/orchestration_stopped.go
@@ -26,6 +26,8 @@ func (t *Manager) freezeStop() {
 	case instance.MonitorStateFreezing:
 		// wait for the freeze exec to end
 	case instance.MonitorStateRunning:
+	case instance.MonitorStateStopped:
+		t.transitionTo(instance.MonitorStateIdle)
 	case instance.MonitorStateStopping:
 		// avoid multiple concurrent stop execs
 	case instance.MonitorStateStopFailed:
@@ -48,6 +50,8 @@ func (t *Manager) stop() {
 		t.doStop()
 	case instance.MonitorStateReady:
 		t.stoppedFromReady()
+	case instance.MonitorStateStopped:
+		t.transitionTo(instance.MonitorStateIdle)
 	case instance.MonitorStateFrozen:
 		// honor the frozen state
 	case instance.MonitorStateFreezing:
@@ -95,7 +99,7 @@ func (t *Manager) doStop() {
 		return
 	}
 	t.createPendingWithDuration(stopDuration)
-	t.queueAction(t.crmStop, instance.MonitorStateStopping, instance.MonitorStateIdle, instance.MonitorStateStopFailed)
+	t.queueAction(t.crmStop, instance.MonitorStateStopping, instance.MonitorStateStopped, instance.MonitorStateStopFailed)
 }
 
 func (t *Manager) stoppedFromReady() {

--- a/daemon/msgbus/messages.go
+++ b/daemon/msgbus/messages.go
@@ -712,18 +712,23 @@ type (
 	}
 
 	ObjectOrchestrationEnd struct {
-		pubsub.Msg `yaml:",inline"`
-		ID         string      `json:"id" yaml:"id"`
-		Node       string      `json:"node" yaml:"node"`
-		Path       naming.Path `json:"path" yaml:"path"`
+		pubsub.Msg            `yaml:",inline"`
+		ID                    string                       `json:"id" yaml:"id"`
+		Node                  string                       `json:"node" yaml:"node"`
+		Path                  naming.Path                  `json:"path" yaml:"path"`
+		GlobalExpect          instance.MonitorGlobalExpect `json:"global_expect" yaml:"global_expect"`
+		GlobalExpectUpdatedAt time.Time                    `json:"global_expect_updated_at" yaml:"global_expect_updated_at"`
+		GlobalExpectOptions   any                          `json:"global_expect_options" yaml:"global_expect_options"`
 	}
 
 	ObjectOrchestrationRefused struct {
-		pubsub.Msg `yaml:",inline"`
-		ID         string      `json:"id" yaml:"id"`
-		Node       string      `json:"node" yaml:"node"`
-		Path       naming.Path `json:"path" yaml:"path"`
-		Reason     string      `json:"reason" yaml:"reason"`
+		pubsub.Msg          `yaml:",inline"`
+		ID                  string                        `json:"id" yaml:"id"`
+		Node                string                        `json:"node" yaml:"node"`
+		Path                naming.Path                   `json:"path" yaml:"path"`
+		Reason              string                        `json:"reason" yaml:"reason"`
+		GlobalExpect        *instance.MonitorGlobalExpect `json:"global_expect" yaml:"global_expect"`
+		GlobalExpectOptions any                           `json:"global_expect_options" yaml:"global_expect_options"`
 	}
 
 	ObjectStatusDeleted struct {


### PR DESCRIPTION
This pull request introduces a "stopped" state in the orchestration stop process to improve handling and transitions.

The changes made include:
- Adding a "stopped" state in both the orchestrateStopped() and stop() functions
- Creating the flow: stopping -> stopped -> idle
- Utilizing the "stopped" state to change the local expectation from started -> none

These updates enhance the handling of orchestrations and ensure correct state transitions where necessary.