### PR TITLE
Refactor orchestrate resource restart

### DIFF
--- a/core/resource/resource.go
+++ b/core/resource/resource.go
@@ -1174,6 +1174,7 @@ func GetStatus(ctx context.Context, r Driver) Status {
 		Log:         r.StatusLog().Entries(),
 		Provisioned: getProvisionStatus(r),
 		Info:        getStatusInfo(ctx, r),
+		Monitor:     MonitorFlag(r.IsMonitored()),
 		Restart:     RestartFlag(r.RestartCount()),
 		Optional:    OptionalFlag(r.IsOptional()),
 		Standby:     StandbyFlag(r.IsStandby()),

--- a/daemon/imon/main.go
+++ b/daemon/imon/main.go
@@ -138,6 +138,16 @@ type (
 		newState instance.MonitorState
 	}
 
+	// cmdResourceRestart is a structure representing a command to restart resources.
+	// It can be used from imon goroutines to schedule a future resource restart
+	// handled during imon main loop.
+	// rids is a slice of resource IDs to restart.
+	// standby indicates whether the resources should restart in standby mode.
+	cmdResourceRestart struct {
+		rids    []string
+		standby bool
+	}
+
 	Factory struct {
 		DrainDuration time.Duration
 		SubQS         pubsub.QueueSizer
@@ -368,6 +378,8 @@ func (t *Manager) worker(initialNodes []string) {
 			switch c := i.(type) {
 			case cmdOrchestrate:
 				t.needOrchestrate(c)
+			case cmdResourceRestart:
+				t.resourceRestart(c.rids, c.standby)
 			}
 		case <-t.delayTimer.C:
 			t.onDelayTimer()

--- a/daemon/imon/orchestration_resource_restart.go
+++ b/daemon/imon/orchestration_resource_restart.go
@@ -245,7 +245,7 @@ func (t *Manager) orchestrateResourceRestart() {
 				t.log.Infof("resource %s status %s, restart remaining %d out of %d", rid, resStatus, rmon.Restart.Remaining, rcfg.Restart)
 				t.setLocalExpect(instance.MonitorLocalExpectEvicted, "monitor action evicting: %s", disableMonitorMsg)
 				t.doMonitorAction(rid, 0)
-			} else {
+			} else if rmon.Restart.Remaining > 0 {
 				t.log.Infof("resource %s status %s, restart remaining %d out of %d", rid, resStatus, rmon.Restart.Remaining, rcfg.Restart)
 				todoRestart.Add(rid)
 			}

--- a/daemon/imon/orchestration_resource_restart.go
+++ b/daemon/imon/orchestration_resource_restart.go
@@ -237,6 +237,9 @@ func (t *Manager) orchestrateResourceRestart() {
 			t.log.Debugf("resource %s restart skip: already has a delay timer", rid)
 		case t.monitorActionCalled():
 			t.log.Debugf("resource %s restart skip: already ran the monitor action", rid)
+		case rcfg.IsStandby:
+			t.log.Infof("resource %s status %s, standby restart remaining %d out of %d", rid, resStatus, rmon.Restart.Remaining, rcfg.Restart)
+			todoStandby.Add(rid)
 		case started:
 			t.log.Infof("resource %s status %s, restart remaining %d out of %d", rid, resStatus, rmon.Restart.Remaining, rcfg.Restart)
 			if rmon.Restart.Remaining == 0 {
@@ -245,9 +248,6 @@ func (t *Manager) orchestrateResourceRestart() {
 			} else {
 				todoRestart.Add(rid)
 			}
-		case rcfg.IsStandby:
-			t.log.Infof("resource %s status %s, standby restart remaining %d out of %d", rid, resStatus, rmon.Restart.Remaining, rcfg.Restart)
-			todoStandby.Add(rid)
 		default:
 			t.log.Debugf("resource %s restart skip: instance not started", rid)
 			resetTimer(rid, rmon)

--- a/daemon/imon/orchestration_resource_restart.go
+++ b/daemon/imon/orchestration_resource_restart.go
@@ -325,8 +325,14 @@ func (t *Manager) orchestrateResourceRestart() {
 	for rid, rstat := range t.instStatus[t.localhost].Resources {
 		planFor(rid, rstat.Status, started)
 	}
-	t.resourceRestartSchedule(todoStandby, true)
-	t.resourceRestartSchedule(todoRestart, false)
+
+	// Prepare scheduled resource restart
+	if len(todoStandby) > 0 {
+		t.resourceRestartSchedule(todoStandby, true)
+	}
+	if len(todoRestart) > 0 {
+		t.resourceRestartSchedule(todoRestart, false)
+	}
 }
 
 // resourceRestartSchedule schedules a restart for resources based on the provided resource map and standby mode.


### PR DESCRIPTION

- [x] Add Monitor flag population in GetStatus for ResourceFlagsString
- [x] Drop unnecessary resourceRestartSchedule call when todo is empty
- [x] Don't restart monitored resources when remaining attempts is 0
- [x] Ensure eviction actions only occur for monitored resources
- [x] Reorder and fix the standby restart logic
- [x] Refactor resource restart handling for possible race
- [x] Implement minimum restart=2 for standby resources