### PR TITLE
Implement more ops for event --filter ...,<jsonpath><op><val>

### DIFF
--- a/core/om/flags.go
+++ b/core/om/flags.go
@@ -17,6 +17,9 @@ import (
 var (
 	//go:embed text/node-events/flag/template
 	usageFlagEventTemplate string
+
+	//go:embed text/node-events/flag/filter
+	usageFlagEventFilter string
 )
 
 func addFlagsAsync(flagSet *pflag.FlagSet, p *commands.OptsAsync) {
@@ -163,7 +166,7 @@ func addFlagEval(flagSet *pflag.FlagSet, p *bool) {
 }
 
 func addFlagEventFilters(flagSet *pflag.FlagSet, p *[]string) {
-	flagSet.StringArrayVar(p, "filter", []string{}, "Request only events matching kind (InstanceStatusUpdated) or labels (path=svc1) or both (InstanceStatusUpdated,path=svc1,node=n1).")
+	flagSet.StringArrayVar(p, "filter", []string{}, usageFlagEventFilter)
 }
 
 func addFlagForeground(flagSet *pflag.FlagSet, p *bool) {

--- a/core/om/text/node-events/flag/filter
+++ b/core/om/text/node-events/flag/filter
@@ -1,0 +1,22 @@
+Receive only events matching the filtering expression formatted as:
+
+<kind>[,filter[,...]]
+where:
+  <kind> is the required event kind
+  <filter> can be:
+    <key>=<value> is a required event label
+    <jsonpath><op><value> is required condition on the event data
+    where:
+      <jsonpath> starts with a dot and is relative to .data
+      <op> can be
+        = or !=
+        > or <
+        >= or <=
+
+Examples:
+  InstanceStatusUpdated
+  InstanceStatusUpdated,path=svc1
+  InstanceStatusUpdated,path=svc1,node=n1
+  InstanceStatusUpdated,path=svc1,node=n1,.instance_status.frozen_at="0001-01-01T00:00:00Z"
+  InstanceStatusUpdated,path=svc1,node=n1,.instance_status.frozen_at>"0001-01-01T00:00:00Z"
+  InstanceStatusUpdated,path=svc1,node=n1,.instance_status.avail="up"

--- a/core/output/flatten.go
+++ b/core/output/flatten.go
@@ -18,9 +18,9 @@ type (
 )
 
 // Flatten accepts a nested struct and returns a flat struct with key like a.'b/c'.d[0].e
-func Flatten(inputJSON interface{}) map[string]interface{} {
+func Flatten(inputJSON interface{}) map[string]string {
 	var lkey = ""
-	var flattened = make(map[string]interface{})
+	var flattened = make(map[string]string)
 	flatten(inputJSON, lkey, &flattened)
 	return flattened
 }
@@ -65,7 +65,7 @@ func sprintFlatData(b []byte) []kv {
 // PrintFlat accepts a JSON formatted byte array and prints to stdout the sorted
 // "key = val"
 func PrintFlat(b []byte) {
-	var data map[string]interface{}
+	var data map[string]string
 	json.Unmarshal(b, &data)
 	flattened := Flatten(data)
 	keys := make([]string, 0)
@@ -78,7 +78,7 @@ func PrintFlat(b []byte) {
 	}
 }
 
-func flatten(value interface{}, lkey string, flattened *map[string]interface{}) {
+func flatten(value interface{}, lkey string, flattened *map[string]string) {
 	v := reflect.ValueOf(value)
 	if value == nil {
 		return

--- a/core/ox/flags.go
+++ b/core/ox/flags.go
@@ -17,6 +17,9 @@ import (
 var (
 	//go:embed text/node-events/flag/template
 	usageFlagEventTemplate string
+
+	//go:embed text/node-events/flag/filter
+	usageFlagEventFilter string
 )
 
 func addFlagsAsync(flagSet *pflag.FlagSet, p *commands.OptsAsync) {
@@ -129,7 +132,7 @@ func addFlagEval(flagSet *pflag.FlagSet, p *bool) {
 }
 
 func addFlagEventFilters(flagSet *pflag.FlagSet, p *[]string) {
-	flagSet.StringArrayVar(p, "filter", []string{}, "Request only events matching kind (InstanceStatusUpdated) or labels (path=svc1) or both (InstanceStatusUpdated,path=svc1,node=n1).")
+	flagSet.StringArrayVar(p, "filter", []string{}, usageFlagEventFilter)
 }
 
 func addFlagForeground(flagSet *pflag.FlagSet, p *bool) {

--- a/core/ox/text/node-events/flag/filter
+++ b/core/ox/text/node-events/flag/filter
@@ -1,0 +1,22 @@
+Receive only events matching the filtering expression formatted as:
+
+<kind>[,filter[,...]]
+where:
+  <kind> is the required event kind
+  <filter> can be:
+    <key>=<value> is a required event label
+    <jsonpath><op><value> is required condition on the event data
+    where:
+      <jsonpath> starts with a dot and is relative to .data
+      <op> can be
+        = or !=
+        > or <
+        >= or <=
+
+Examples:
+  InstanceStatusUpdated
+  InstanceStatusUpdated,path=svc1
+  InstanceStatusUpdated,path=svc1,node=n1
+  InstanceStatusUpdated,path=svc1,node=n1,.instance_status.frozen_at="0001-01-01T00:00:00Z"
+  InstanceStatusUpdated,path=svc1,node=n1,.instance_status.frozen_at>"0001-01-01T00:00:00Z"
+  InstanceStatusUpdated,path=svc1,node=n1,.instance_status.avail="up"

--- a/daemon/daemonapi/get_daemon_events.go
+++ b/daemon/daemonapi/get_daemon_events.go
@@ -489,6 +489,9 @@ func parseFilters(params api.GetDaemonEventsParams) (filters []Filter, err error
 		if err != nil {
 			return
 		}
+		if filter.IsZero() {
+			continue
+		}
 		if k, ok := filter.Kind.(kinder); ok {
 			kind := k.Kind()
 			hasMatcher, alreadyFiltered := matchKind[kind]
@@ -601,6 +604,10 @@ func parseFilter(filterStr string) (Filter, error) {
 		}
 	}
 	return filter, nil
+}
+
+func (f Filter) IsZero() bool {
+	return f.Kind == nil && len(f.DataFilters) == 0 && len(f.Labels) == 0
 }
 
 func (df DataFilters) match(i any) bool {

--- a/daemon/daemonapi/get_daemon_events_test.go
+++ b/daemon/daemonapi/get_daemon_events_test.go
@@ -29,14 +29,9 @@ func TestGetDaemonEventsParamsOk(t *testing.T) {
 				},
 			},
 		},
-		"xxx": {
-			filterS: []string{"ObjectStatusUpdated,path=root/svc/foo"},
-			expected: []Filter{
-				{
-					Kind:   &msgbus.ObjectStatusUpdated{},
-					Labels: []pubsub.Label{{"path", "root/svc/foo"}},
-				},
-			},
+		",": {
+			filterS:  []string{","},
+			expected: nil,
 		},
 		"types and labels": {
 			filterS: []string{"ObjectStatusUpdated,path=root/svc/foo", "ConfigFileRemoved,path=root/svc/bar"},
@@ -87,6 +82,14 @@ func TestGetDaemonEventsParamsOk(t *testing.T) {
 			},
 		},
 		"only label": {
+			filterS: []string{"path=root/svc/foo"},
+			expected: []Filter{
+				{
+					Labels: []pubsub.Label{{"path", "root/svc/foo"}},
+				},
+			},
+		},
+		"only label with heading comma": {
 			filterS: []string{",path=root/svc/foo"},
 			expected: []Filter{
 				{
@@ -143,25 +146,13 @@ func TestGetDaemonEventsBadParams(t *testing.T) {
 		filterS []string
 		err     error
 	}{
-		"missing label and matcher": {
-			filterS: []string{","},
-			err:     fmt.Errorf("invalid filter expression: ,"),
-		},
-		"empty label or matcher": {
-			filterS: []string{",=foo"},
-			err:     fmt.Errorf("invalid filter expression with empty matcher key: ,=foo"),
-		},
 		"invalid kind": {
 			filterS: []string{"Plop"},
 			err:     fmt.Errorf("can't find type for kind: Plop"),
 		},
-		"missing kind": {
-			filterS: []string{"path=foo"},
-			err:     fmt.Errorf("can't find type for kind: path=foo"),
-		},
 		"missing label key": {
 			filterS: []string{",=foo"},
-			err:     fmt.Errorf("invalid filter expression with empty matcher key: ,=foo"),
+			err:     fmt.Errorf("invalid label filter expression: =foo (empty key)"),
 		},
 		"multiple value filters for same kind": {
 			filterS: []string{"InstanceStatusUpdated,.data.instance_status=up", "InstanceStatusUpdated"},


### PR DESCRIPTION
Update the command flag doc to reflect the need possibilities:

Receive only events matching the filtering expression formatted as:

<kind>[,filter[,...]]
where:
  <kind> is the required event kind
  <filter> can be:
    <key>=<value> is a required event label
    <jsonpath><op><value> is required condition on the event data
    where:
      <jsonpath> starts with a dot and is relative to .data
      <op> can be
        = or !=
        > or <
        >= or <=

Examples:
  InstanceStatusUpdated
  InstanceStatusUpdated,path=svc1
  InstanceStatusUpdated,path=svc1,node=n1
  InstanceStatusUpdated,path=svc1,node=n1,.instance_status.frozen_at="0001-01-01T00:00:00Z"
  InstanceStatusUpdated,path=svc1,node=n1,.instance_status.frozen_at>"0001-01-01T00:00:00Z"
  InstanceStatusUpdated,path=svc1,node=n1,.instance_status.avail="up"