### PR TITLE
Fix event filtering and orchestration reliability issues

### DIFF
--- a/core/nodeaction/node.go
+++ b/core/nodeaction/node.go
@@ -472,8 +472,8 @@ func (t T) waitRequesterSessionEnd(ctx context.Context, c *client.T, nodename st
 	)
 	filters = []string{
 		fmt.Sprintf("NodeMonitorDeleted"),
-		fmt.Sprintf("ExecFailed,requester_sid=%s", requesterSid),
-		fmt.Sprintf("ExecSuccess,requester_sid=%s", requesterSid),
+		fmt.Sprintf("ExecFailed,.requester_session_id=%s", requesterSid),
+		fmt.Sprintf("ExecSuccess,.requester_session_id=%s", requesterSid),
 	}
 	getEvents := c.NewGetEvents().SetFilters(filters)
 	if t.WaitDuration > 0 {

--- a/core/objectaction/object.go
+++ b/core/objectaction/object.go
@@ -1008,8 +1008,8 @@ func (t T) waitRequesterSessionEnd(ctx context.Context, c *client.T, requesterSi
 	)
 	filters = []string{
 		fmt.Sprintf("ObjectStatusDeleted,path=%s", p),
-		fmt.Sprintf("ExecFailed,path=%s,requester_sid=%s", p, requesterSid),
-		fmt.Sprintf("ExecSuccess,path=%s,requester_sid=%s", p, requesterSid),
+		fmt.Sprintf("ExecFailed,path=%s,.requester_session_id=%s", p, requesterSid),
+		fmt.Sprintf("ExecSuccess,path=%s,.requester_session_id=%s", p, requesterSid),
 	}
 	getEvents := c.NewGetEvents().SetFilters(filters)
 	if t.WaitDuration > 0 {

--- a/core/objectaction/object.go
+++ b/core/objectaction/object.go
@@ -929,9 +929,11 @@ func (t T) waitExpectation(ctx context.Context, c *client.T, expectation string,
 		err      error
 		evReader event.ReadCloser
 	)
+	// TODO: make a choice, wait for ObjectOrchestrationEnd in not enought
+	// We have to also verify final status to decide if it is a success or not
 	switch expectation {
 	case instance.MonitorGlobalExpectPurged.String():
-		filters = []string{"ObjectStatusDeleted,path=" + p.String()}
+		filters = []string{"ObjectStatusDeleted,path=" + p.String(), "ObjectOrchestrationEnd,path=" + p.String()}
 	default:
 		filters = []string{"ObjectOrchestrationEnd,path=" + p.String()}
 	}

--- a/core/objectaction/object.go
+++ b/core/objectaction/object.go
@@ -933,7 +933,7 @@ func (t T) waitExpectation(ctx context.Context, c *client.T, expectation string,
 	case instance.MonitorGlobalExpectPurged.String():
 		filters = []string{"ObjectStatusDeleted,path=" + p.String()}
 	default:
-		filters = []string{"InstanceMonitorUpdated,path=" + p.String()}
+		filters = []string{"ObjectOrchestrationEnd,path=" + p.String()}
 	}
 	filters = append(filters, "SetInstanceMonitorRefused,path="+p.String())
 	getEvents := c.NewGetEvents().SetFilters(filters)
@@ -985,9 +985,9 @@ func (t T) waitExpectation(ctx context.Context, c *client.T, expectation string,
 				err = fmt.Errorf("%s: can't wait expectation %s, got SetInstanceMonitorRefused", p, expectation)
 				log.Debug().Msgf("%s", err)
 				return
-			case *msgbus.InstanceMonitorUpdated:
-				if m.Value.GlobalExpect == instance.MonitorGlobalExpectNone {
-					log.Debug().Msgf("%s: reached expectation %s (global expect is %s)", p, expectation, m.Value.GlobalExpect)
+			case *msgbus.ObjectOrchestrationEnd:
+				if instance.MonitorGlobalExpectValues[t.Target] == m.GlobalExpect {
+					log.Debug().Msgf("%s: reached expectation %s (global expect was %s id: %s)", p, expectation, m.GlobalExpect, m.ID)
 					return
 				}
 			case *msgbus.ObjectStatusDeleted:

--- a/daemon/daemondata/apply_patch.go
+++ b/daemon/daemondata/apply_patch.go
@@ -199,6 +199,10 @@ func (d *data) setCacheAndPublish(ev event.Event) error {
 	// object...
 	case *msgbus.ObjectCreated:
 		d.publisher.Pub(c, labelFromPeer)
+	case *msgbus.ObjectOrchestrationEnd:
+		d.publisher.Pub(c, labelFromPeer)
+	case *msgbus.ObjectOrchestrationRefused:
+		d.publisher.Pub(c, labelFromPeer)
 	case *msgbus.ObjectStatusDeleted:
 		d.publisher.Pub(c, labelFromPeer)
 	default:

--- a/daemon/daemondata/data.go
+++ b/daemon/daemondata/data.go
@@ -418,6 +418,8 @@ func (d *data) startSubscriptions(ctx context.Context, qs pubsub.QueueSizer) {
 	// need forward to peers
 	sub.AddFilter(&msgbus.ObjectCreated{}, d.labelLocalhost)
 	sub.AddFilter(&msgbus.ObjectStatusDeleted{}, d.labelLocalhost)
+	sub.AddFilter(&msgbus.ObjectOrchestrationEnd{}, d.labelLocalhost)
+	sub.AddFilter(&msgbus.ObjectOrchestrationRefused{}, d.labelLocalhost)
 	sub.AddFilter(&msgbus.ObjectStatusUpdated{}, d.labelLocalhost)
 	sub.Start()
 	d.sub = sub
@@ -468,6 +470,8 @@ func localEventMustBeForwarded(i interface{}) bool {
 	case *msgbus.NodeStatusUpdated:
 	// object...
 	case *msgbus.ObjectCreated:
+	case *msgbus.ObjectOrchestrationEnd:
+	case *msgbus.ObjectOrchestrationRefused:
 	case *msgbus.ObjectStatusDeleted:
 	default:
 		return false

--- a/daemon/imon/orchestration_purged.go
+++ b/daemon/imon/orchestration_purged.go
@@ -72,7 +72,7 @@ func (t *Manager) purgedFromUnprovisioned() {
 
 func (t *Manager) purgedFromIdleUp() {
 	t.disableMonitor("orchestrate purged stopping")
-	t.queueAction(t.crmStop, instance.MonitorStateStopProgress, instance.MonitorStateStopSuccess, instance.MonitorStateStopFailure)
+	t.queueAction(t.crmStop, instance.MonitorStateStopProgress, instance.MonitorStateStopSuccess, instance.MonitorStatePurgeFailed)
 }
 
 func (t *Manager) purgedFromIdleProvisioned() {

--- a/daemon/imon/orchestration_purged.go
+++ b/daemon/imon/orchestration_purged.go
@@ -21,6 +21,8 @@ func (t *Manager) orchestratePurged() {
 		t.purgedFromUnprovisioned()
 	case instance.MonitorStateWaitNonLeader:
 		t.purgedFromWaitNonLeader()
+	case instance.MonitorStatePurgeFailed:
+		t.done()
 	case instance.MonitorStateUnprovisionProgress,
 		instance.MonitorStateDeleteProgress,
 		instance.MonitorStateRunning,

--- a/daemon/imon/orchestration_stopped.go
+++ b/daemon/imon/orchestration_stopped.go
@@ -31,7 +31,7 @@ func (t *Manager) freezeStop() {
 	case instance.MonitorStateStopProgress:
 		// avoid multiple concurrent stop execs
 	case instance.MonitorStateStopFailure:
-		// avoid a retry-loop
+		t.done()
 	case instance.MonitorStateStartFailure:
 		t.stoppedFromFailed()
 	case instance.MonitorStateWaitChildren:

--- a/daemon/msgbus/instance_config.go
+++ b/daemon/msgbus/instance_config.go
@@ -43,6 +43,9 @@ func (data *ClusterData) instanceConfigUpdated(labels pubsub.Labels) ([]any, err
 			continue
 		}
 		for instancePath, instanceData := range nodeData.Instance {
+			if instanceData.Config == nil {
+				continue
+			}
 			if path != "" && path != instancePath {
 				continue
 			}

--- a/daemon/msgbus/instance_monitor.go
+++ b/daemon/msgbus/instance_monitor.go
@@ -43,6 +43,9 @@ func (data *ClusterData) instanceMonitorUpdated(labels pubsub.Labels) ([]any, er
 			continue
 		}
 		for instancePath, instanceData := range nodeData.Instance {
+			if instanceData.Monitor == nil {
+				continue
+			}
 			if path != "" && path != instancePath {
 				continue
 			}

--- a/daemon/msgbus/instance_status.go
+++ b/daemon/msgbus/instance_status.go
@@ -43,6 +43,9 @@ func (data *ClusterData) instanceStatusUpdated(labels pubsub.Labels) ([]any, err
 			continue
 		}
 		for instancePath, instanceData := range nodeData.Instance {
+			if instanceData.Status == nil {
+				continue
+			}
 			if path != "" && path != instancePath {
 				continue
 			}


### PR DESCRIPTION
### Description

This pull request addresses the following issues:

1. **Fix nil pointer dereference during event filtering**:
   - Added checks to ensure `Monitor`, `Status`, and `Config` fields of instances are not nil before processing.
   - Prevents runtime panics caused by nil pointers during event filtering.

2. **Ensure finalization of tasks during stop failure handling in `imon`**:
   - Added a missing call to `t.done()` during stop failure handling to prevent incomplete task states.

3. **Improve reliability of `--wait` during object actions**:
   - Changed the waiting condition from `InstanceMonitorUpdated` to `ObjectOrchestrationEnd` for better accuracy and to avoid premature termination of the waiting process. 

These changes collectively enhance the robustness and reliability of the system