### PR TITLE
Fix DeepCopy issues and enhance error handling for Enter command

### DIFF
--- a/core/cluster/data.go
+++ b/core/cluster/data.go
@@ -12,9 +12,16 @@ type (
 		sync.RWMutex
 		data *T
 	}
+
+	deepCopyer[T Dataer] interface {
+		DeepCopy() *T
+	}
 )
 
 var (
+	// _ ensures that *Config implements the deepCopyer[Config] interface.
+	_ deepCopyer[Config] = (*Config)(nil)
+
 	// ConfigData is the package data holder for local cluster config
 	ConfigData *DataT[Config]
 )
@@ -52,9 +59,6 @@ func InitData() {
 func deepCopy[T Dataer](t *T) *T {
 	if t == nil {
 		return t
-	}
-	type deepCopyer[T Dataer] interface {
-		DeepCopy() *T
 	}
 	var i any = t
 	return i.(deepCopyer[T]).DeepCopy()

--- a/core/instance/data.go
+++ b/core/instance/data.go
@@ -24,9 +24,18 @@ type (
 		pathToNode map[naming.Path]map[string]struct{}
 		data       map[string]*T
 	}
+
+	deepCopyer[T Dataer] interface {
+		DeepCopy() *T
+	}
 )
 
 var (
+	// _ ensures that *Status, *Monitor and *Config implements the deepCopyer[Status] interface.
+	_ deepCopyer[Status]  = (*Status)(nil)
+	_ deepCopyer[Monitor] = (*Monitor)(nil)
+	_ deepCopyer[Config]  = (*Config)(nil)
+
 	// StatusData is the package data holder for all instances statuses
 	StatusData *Data[Status]
 
@@ -148,9 +157,6 @@ func InitData() {
 func deepCopy[T Dataer](t *T) *T {
 	if t == nil {
 		return t
-	}
-	type deepCopyer[T Dataer] interface {
-		DeepCopy() *T
 	}
 	var i any = t
 	return i.(deepCopyer[T]).DeepCopy()

--- a/core/node/data.go
+++ b/core/node/data.go
@@ -23,9 +23,21 @@ type (
 		sync.RWMutex
 		data map[string]*T
 	}
+
+	deepCopyer[T Dataer] interface {
+		DeepCopy() *T
+	}
 )
 
 var (
+	// _ ensures implements the deepCopyer[] interface.
+	_ deepCopyer[Config]    = (*Config)(nil)
+	_ deepCopyer[Monitor]   = (*Monitor)(nil)
+	_ deepCopyer[san.Paths] = (*san.Paths)(nil)
+	_ deepCopyer[Stats]     = (*Stats)(nil)
+	_ deepCopyer[Status]    = (*Status)(nil)
+	_ deepCopyer[Gen]       = (*Gen)(nil)
+
 	// ConfigData is the package data holder for all nodes Configs
 	ConfigData *Data[Config]
 
@@ -116,9 +128,6 @@ func (t *Gen) DeepCopy() *Gen {
 func deepCopy[T Dataer](t *T) *T {
 	if t == nil {
 		return t
-	}
-	type deepCopyer[T Dataer] interface {
-		DeepCopy() *T
 	}
 	var i any = t
 	return i.(deepCopyer[T]).DeepCopy()

--- a/core/object/actor_enter.go
+++ b/core/object/actor_enter.go
@@ -20,7 +20,10 @@ func (t *actor) Enter(ctx context.Context, rid string) error {
 			t.Log().Debugf("skip %s: not enterer", r.RID())
 			continue
 		}
-		return i.Enter()
+		if err := i.Enter(); err != nil {
+			return fmt.Errorf("%s: %w", r.RID(), err)
+		}
+		return nil
 	}
 	return fmt.Errorf("no resource supports enter")
 }

--- a/core/object/data.go
+++ b/core/object/data.go
@@ -21,9 +21,16 @@ type (
 		sync.RWMutex
 		data map[naming.Path]*T
 	}
+
+	deepCopyer[T Dataer] interface {
+		DeepCopy() *T
+	}
 )
 
 var (
+	// _ ensures that *Status implements the deepCopyer[Status] interface.
+	_ deepCopyer[Status] = (*Status)(nil)
+
 	// StatusData is the package data holder for all objects statuses
 	StatusData *Data[Status]
 )
@@ -87,9 +94,6 @@ func init() {
 func deepCopy[T Dataer](t *T) *T {
 	if t == nil {
 		return t
-	}
-	type deepCopyer[T Dataer] interface {
-		DeepCopy() *T
 	}
 	var i any = t
 	return i.(deepCopyer[T]).DeepCopy()

--- a/core/pool/data.go
+++ b/core/pool/data.go
@@ -19,9 +19,16 @@ type (
 		sync.RWMutex
 		data map[string]*T
 	}
+
+	deepCopyer[T Dataer] interface {
+		DeepCopy() *T
+	}
 )
 
 var (
+	// _ ensures that *Status implements the deepCopyer[Status] interface.
+	_ deepCopyer[Status] = (*Status)(nil)
+
 	// StatusData is the package data holder for all instances statuses
 	StatusData *Data[Status]
 )
@@ -75,9 +82,6 @@ func InitData() {
 func deepCopy[T Dataer](t *T) *T {
 	if t == nil {
 		return t
-	}
-	type deepCopyer[T Dataer] interface {
-		DeepCopy() *T
 	}
 	var i any = t
 	return i.(deepCopyer[T]).DeepCopy()

--- a/core/schedule/data.go
+++ b/core/schedule/data.go
@@ -21,9 +21,16 @@ type (
 		sync.RWMutex
 		data map[naming.Path]*T
 	}
+
+	deepCopyer[T Dataer] interface {
+		DeepCopy() *T
+	}
 )
 
 var (
+	// _ ensures that *Table implements the deepCopyer[Config] interface.
+	_ deepCopyer[Table] = (*Table)(nil)
+
 	// TableData is the package data holder for all objects schedule
 	TableData *Data[Table]
 )
@@ -84,9 +91,6 @@ func InitData() {
 func deepCopy[T Dataer](t *T) *T {
 	if t == nil {
 		return t
-	}
-	type deepCopyer[T Dataer] interface {
-		DeepCopy() *T
 	}
 	var i any = t
 	return i.(deepCopyer[T]).DeepCopy()

--- a/core/schedule/main.go
+++ b/core/schedule/main.go
@@ -94,6 +94,28 @@ func (t Table) AddEntries(l ...Entry) Table {
 	return append(t, l...)
 }
 
+func (t Table) DeepCopy() *Table {
+	r := make(Table, 0, len(t))
+	for _, x := range t {
+		r = append(r, Entry{
+			Action:             x.Action,
+			Schedule:           x.Schedule,
+			Key:                x.Key,
+			LastRunAt:          x.LastRunAt,
+			LastRunFile:        x.LastRunFile,
+			LastSuccessFile:    x.LastSuccessFile,
+			MaxParallel:        x.MaxParallel,
+			NextRunAt:          x.NextRunAt,
+			Node:               x.Node,
+			Path:               x.Path,
+			RequireCollector:   x.RequireCollector,
+			RequireProvisioned: x.RequireProvisioned,
+			RunDir:             x.RunDir,
+		})
+	}
+	return &r
+}
+
 func (t Entry) GetNext() (time.Time, time.Duration, error) {
 	sc := usched.New(t.Schedule)
 	return sc.Next(usched.NextWithLast(t.LastRunAt))

--- a/daemon/daemonsubsystem/cache.go
+++ b/daemon/daemonsubsystem/cache.go
@@ -19,9 +19,22 @@ type (
 		sync.RWMutex
 		data map[string]*T
 	}
+
+	deepCopyer[T Cacher] interface {
+		DeepCopy() *T
+	}
 )
 
 var (
+	// _ ensures implements the deepCopyer[] interface.
+	_ deepCopyer[Collector]  = (*Collector)(nil)
+	_ deepCopyer[Dns]        = (*Dns)(nil)
+	_ deepCopyer[Daemondata] = (*Daemondata)(nil)
+	_ deepCopyer[Heartbeat]  = (*Heartbeat)(nil)
+	_ deepCopyer[Listener]   = (*Listener)(nil)
+	_ deepCopyer[RunnerImon] = (*RunnerImon)(nil)
+	_ deepCopyer[Scheduler]  = (*Scheduler)(nil)
+
 	// DataCollector is the package data holder for all nodes Collector
 	DataCollector *CacheData[Collector]
 
@@ -109,9 +122,6 @@ func InitData() {
 func deepCopy[T Cacher](t *T) *T {
 	if t == nil {
 		return t
-	}
-	type deepCopyer[T Cacher] interface {
-		DeepCopy() *T
 	}
 	var i any = t
 	return i.(deepCopyer[T]).DeepCopy()

--- a/daemon/nmon/main.go
+++ b/daemon/nmon/main.go
@@ -698,9 +698,8 @@ func (t *Manager) loadAndPublishConfig() error {
 	t.nodeStatus.Labels = localNodeInfo.Labels
 	t.publishNodeStatus()
 
-	paths := localNodeInfo.Paths.DeepCopy()
-	node.OsPathsData.Set(t.localhost, &paths)
-	t.publisher.Pub(&msgbus.NodeOsPathsUpdated{Node: t.localhost, Value: localNodeInfo.Paths.DeepCopy()}, t.labelLocalhost)
+	node.OsPathsData.Set(t.localhost, localNodeInfo.Paths.DeepCopy())
+	t.publisher.Pub(&msgbus.NodeOsPathsUpdated{Node: t.localhost, Value: *localNodeInfo.Paths.DeepCopy()}, t.labelLocalhost)
 
 	select {
 	case t.poolC <- nil:

--- a/drivers/rescontainerocibase/executor.go
+++ b/drivers/rescontainerocibase/executor.go
@@ -64,7 +64,7 @@ outerLoop:
 	}
 	cancel()
 	if enterCmd == "" {
-		return fmt.Errorf("can''t enter: container needs at least one of following command: %s",
+		return fmt.Errorf("can't enter: container needs at least one of following command: %s",
 			strings.Join(candidates, ", "))
 	}
 	cmd := exec.Command(e.bin, append(e.args.EnterCmdArgs(), enterCmd)...)

--- a/util/san/main.go
+++ b/util/san/main.go
@@ -202,12 +202,12 @@ func (t Paths) HasAnyOf(paths Paths) bool {
 	return false
 }
 
-func (t Paths) DeepCopy() Paths {
+func (t Paths) DeepCopy() *Paths {
 	l := make(Paths, len(t))
 	for i, p := range t {
 		l[i] = p.DeepCopy()
 	}
-	return l
+	return &l
 }
 
 func (t Path) DeepCopy() Path {


### PR DESCRIPTION
### Description
This pull request addresses several significant issues:

- **Logging Enhancements**: Logs the resource ID when the `Enter` command fails for better debugging and tracking.
- **Error Message Fix**: Corrects a typo in the error message for missing container command during the `Enter` operation.
- **DeepCopy Implementation**: Adds the missing DeepCopy method for `*Paths` and ensures the `deepCopyer` interface is implemented for relevant cached types.
- **500 Error Fix**: Resolves a server panic caused by the `GET /node/name/:nodename/schedule` endpoint due to a missing DeepCopy method in the `schedule.Table` implementation.

### Notes for Reviewers
Pay special attention to the new DeepCopy method implementations and ensure identified logging points provide meaningful debugging information