### PR TITLE
Handle early abort and refactor orchestration end handling

### DIFF
--- a/daemon/imon/main.go
+++ b/daemon/imon/main.go
@@ -49,6 +49,10 @@ type (
 		state         instance.Monitor
 		previousState instance.Monitor
 
+		// abortedOrchestration represents the state of an orchestration process
+		// that was prematurely aborted.
+		abortedOrchestration *orchestrationEnd
+
 		path    naming.Path
 		id      string
 		ctx     context.Context
@@ -164,6 +168,19 @@ type (
 		DrainDuration time.Duration
 		SubQS         pubsub.QueueSizer
 		DelayDuration time.Duration
+	}
+
+	// orchestrationEnd is a helper data structure representing the end state of
+	// an orchestration process, it is used to publish ObjectOrchestrationEnd.
+	// orchestrationID is the UUID of the accepted orchestration.
+	// globalExpect represents the desired global state of the instance.
+	// globalExpectUpdateAt is the timestamp of when the global expectation was updated.
+	// globalExpectOptions holds additional options relevant to the global expectation.
+	orchestrationEnd struct {
+		orchestrationID      uuid.UUID
+		globalExpect         instance.MonitorGlobalExpect
+		globalExpectUpdateAt time.Time
+		globalExpectOptions  any
 	}
 )
 

--- a/daemon/imon/main_cmd.go
+++ b/daemon/imon/main_cmd.go
@@ -527,6 +527,11 @@ func (t *Manager) onSetInstanceMonitor(c *msgbus.SetInstanceMonitor) {
 		}
 
 		if *c.Value.GlobalExpect != t.state.GlobalExpect {
+			if *c.Value.GlobalExpect == instance.MonitorGlobalExpectAborted && t.state.GlobalExpect != instance.MonitorGlobalExpectNone {
+				// This is an abort orchestration, pickup the pending orchestration
+				// it will be used to publish ObjectOrchestrationEnd with abort true
+				t.abortedOrchestration = t.getOrchestrationEnd()
+			}
 			t.change = true
 			t.state.GlobalExpect = *c.Value.GlobalExpect
 			t.state.GlobalExpectOptions = c.Value.GlobalExpectOptions

--- a/daemon/imon/orchestration_aborted.go
+++ b/daemon/imon/orchestration_aborted.go
@@ -1,11 +1,8 @@
 package imon
 
-import "github.com/opensvc/om3/core/instance"
-
 func (t *Manager) orchestrateAborted() {
 	t.log.Infof("abort orchestration: unset global expect")
 	t.change = true
-	t.state.GlobalExpect = instance.MonitorGlobalExpectNone
 	t.state.GlobalExpectOptions = nil
 	t.state.OrchestrationIsDone = true
 	t.updateIfChange()

--- a/daemon/msgbus/messages.go
+++ b/daemon/msgbus/messages.go
@@ -726,6 +726,7 @@ type (
 		GlobalExpect          instance.MonitorGlobalExpect `json:"global_expect" yaml:"global_expect"`
 		GlobalExpectUpdatedAt time.Time                    `json:"global_expect_updated_at" yaml:"global_expect_updated_at"`
 		GlobalExpectOptions   any                          `json:"global_expect_options" yaml:"global_expect_options"`
+		Aborted               bool                         `json:"aborted" yaml:"aborted"`
 	}
 
 	ObjectOrchestrationRefused struct {


### PR DESCRIPTION

This pull request addresses two key improvements:

1. **Preventing Wait Hang During Early Abort**:
   - Ensures recent abort orchestrations are detected even when the orchestration end event has not been published.
   - Improves system reliability and prevents hangs caused by incomplete abort processing.

2. **Refactoring Orchestration End Handling**:
   - Introduces an `aborted` boolean in `ObjectOrchestrationEnd` events.
   - Adds support for publishing `ObjectOrchestrationEnd` events for aborted orchestrations, with appropriate values for the `aborted` field.
   - Implements a new `orchestrationEnd` struct to encapsulate related data, enhancing code clarity and maintainability.
