### PR TITLE
[ox,om] Integrate shared command functionality and fix log -o json rendering

### DIFF
--- a/core/commoncmd/main.go
+++ b/core/commoncmd/main.go
@@ -1,0 +1,45 @@
+// Package commoncmd provides utilities and shared functionality to facilitate
+// operations related to managing remotes objects, nodes, and logs for omcmd
+// and oxcmd.
+package commoncmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opensvc/om3/core/client"
+	"github.com/opensvc/om3/daemon/api"
+	"github.com/opensvc/om3/util/xmap"
+)
+
+type (
+	OptsGlobal struct {
+		Color          string
+		Output         string
+		ObjectSelector string
+	}
+
+	OptsLogs struct {
+		Follow bool
+		Lines  int
+		Filter []string
+	}
+)
+
+func NodesFromPaths(c *client.T, selector string) ([]string, error) {
+	m := make(map[string]any)
+	params := api.GetObjectsParams{Path: &selector}
+	resp, err := c.GetObjectsWithResponse(context.Background(), &params)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("%s", resp.Status())
+	}
+	for _, item := range resp.JSON200.Items {
+		for node := range item.Data.Instances {
+			m[node] = nil
+		}
+	}
+	return xmap.Keys(m), nil
+}

--- a/core/commoncmd/node_log.go
+++ b/core/commoncmd/node_log.go
@@ -1,0 +1,85 @@
+package commoncmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/opensvc/om3/core/client"
+	"github.com/opensvc/om3/core/nodeselector"
+	"github.com/opensvc/om3/core/streamlog"
+)
+
+type (
+	// CmdNodeLogs duplicates the omcmd and oxcmd CmdNodeLogs configuration for
+	// fetching logs from nodes based on the specified NodeSelector.
+	CmdNodeLogs struct {
+		OptsGlobal
+		OptsLogs
+		NodeSelector string
+	}
+)
+
+// Remote fetches logs remotely from the nodes specified by the NodeSelector,
+// using concurrent streaming for each node.
+// Returns an error if the client setup fails, no nodes are selected,
+// or if there are issues during the process.
+func (t *CmdNodeLogs) Remote() error {
+	c, err := client.New(client.WithTimeout(0))
+	if err != nil {
+		return err
+	}
+	nodes, err := nodeselector.New(t.NodeSelector, nodeselector.WithClient(c)).Expand()
+	if err != nil {
+		return err
+	}
+	if len(nodes) == 0 {
+		return fmt.Errorf("no nodes to fetch logs from")
+	}
+	var wg sync.WaitGroup
+	wg.Add(len(nodes))
+	for _, node := range nodes {
+		go func(n string) {
+			defer wg.Done()
+			t.stream(n)
+		}(node)
+	}
+	wg.Wait()
+	return nil
+}
+
+func (t *CmdNodeLogs) stream(node string) {
+	c, err := client.New(client.WithTimeout(0))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	reader, err := c.NewGetLogs(node).
+		SetFilters(&t.Filter).
+		SetLines(&t.Lines).
+		SetFollow(&t.Follow).
+		GetReader()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	defer reader.Close()
+
+	for {
+		event, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			break
+		}
+		rec, err := streamlog.NewEvent(event.Data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			break
+		}
+		rec.Render(t.Output)
+	}
+}

--- a/core/commoncmd/object_log.go
+++ b/core/commoncmd/object_log.go
@@ -1,0 +1,96 @@
+package commoncmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/opensvc/om3/core/client"
+	"github.com/opensvc/om3/core/naming"
+	"github.com/opensvc/om3/core/nodeselector"
+	"github.com/opensvc/om3/core/objectselector"
+	"github.com/opensvc/om3/core/streamlog"
+)
+
+type (
+	// CmdObjectLogs duplicates the omcmd and oxcmd CmdObjectLogs configuration
+	// for fetching logs from nodes based on the specified NodeSelector.
+	CmdObjectLogs struct {
+		OptsGlobal
+		OptsLogs
+		NodeSelector string
+	}
+)
+
+// Remote executes the object log retrieval operation for selected nodes and
+// paths in an asynchronous manner.
+// It leverages the provided selector string to identify target objects and
+// nodes for log streaming.
+func (t *CmdObjectLogs) Remote(selStr string) error {
+	var (
+		paths naming.Paths
+		nodes []string
+		err   error
+	)
+	c, err := client.New(client.WithTimeout(0))
+	if err != nil {
+		return err
+	}
+	if paths, err = objectselector.New(selStr, objectselector.WithClient(c)).MustExpand(); err != nil {
+		return err
+	}
+	if t.NodeSelector != "" {
+		nodes, err = nodeselector.New(t.NodeSelector, nodeselector.WithClient(c)).Expand()
+		if err != nil {
+			return err
+		}
+	} else {
+		nodes, err = NodesFromPaths(c, selStr)
+		if err != nil {
+			return err
+		}
+	}
+	var wg sync.WaitGroup
+	wg.Add(len(nodes))
+	for _, node := range nodes {
+		go func(n string) {
+			defer wg.Done()
+			t.stream(c, n, paths)
+		}(node)
+	}
+	wg.Wait()
+	return nil
+}
+
+func (t *CmdObjectLogs) stream(c *client.T, node string, paths naming.Paths) {
+	l := paths.StrSlice()
+	reader, err := c.NewGetLogs(node).
+		SetFilters(&t.Filter).
+		SetLines(&t.Lines).
+		SetFollow(&t.Follow).
+		SetPaths(&l).
+		GetReader()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	defer reader.Close()
+
+	for {
+		event, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			break
+		}
+		rec, err := streamlog.NewEvent(event.Data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			break
+		}
+		rec.Render(t.Output)
+	}
+}

--- a/core/event/sseevent/main.go
+++ b/core/event/sseevent/main.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"time"
@@ -105,8 +106,16 @@ func (r *ReadCloser) Read() (*event.Event, error) {
 	case <-r.ctx.Done():
 		return nil, r.ctx.Err()
 	case err := <-r.errC:
+		if err == nil {
+			// bug
+			return nil, fmt.Errorf("event reader: read unexpected nil from err channel")
+		}
 		return nil, err
 	case e := <-r.eventC:
+		if e == nil {
+			// bug
+			return nil, fmt.Errorf("event reader: read unexpected nil from event channel")
+		}
 		return e, nil
 	}
 }

--- a/core/omcmd/node_logs.go
+++ b/core/omcmd/node_logs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/opensvc/om3/core/commoncmd"
 	"github.com/opensvc/om3/core/streamlog"
 	"github.com/opensvc/om3/util/render"
 )
@@ -15,6 +16,18 @@ type (
 		NodeSelector string
 	}
 )
+
+func (t *CmdNodeLogs) Run() error {
+	render.SetColor(t.Color)
+	if t.NodeSelector == "" {
+		t.NodeSelector = "*"
+	}
+	if t.Local {
+		return t.local()
+	} else {
+		return t.asCommonCmd().Remote()
+	}
+}
 
 func parseFilters(l *[]string) []string {
 	m := make([]string, 0)
@@ -51,10 +64,18 @@ func (t *CmdNodeLogs) local() error {
 	}
 }
 
-func (t *CmdNodeLogs) Run() error {
-	render.SetColor(t.Color)
-	if t.NodeSelector == "" {
-		t.NodeSelector = "*"
+func (t *CmdNodeLogs) asCommonCmd() *commoncmd.CmdNodeLogs {
+	return &commoncmd.CmdNodeLogs{
+		OptsGlobal: commoncmd.OptsGlobal{
+			Color:          t.Color,
+			Output:         t.Output,
+			ObjectSelector: t.ObjectSelector,
+		},
+		OptsLogs: commoncmd.OptsLogs{
+			Follow: t.Follow,
+			Lines:  t.Lines,
+			Filter: t.Filter,
+		},
+		NodeSelector: t.NodeSelector,
 	}
-	return t.local()
 }

--- a/core/omcmd/object_clear.go
+++ b/core/omcmd/object_clear.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/opensvc/om3/core/client"
+	"github.com/opensvc/om3/core/commoncmd"
 	"github.com/opensvc/om3/core/objectselector"
 )
 
@@ -29,7 +30,7 @@ func (t *CmdObjectClear) Run(selector, kind string) error {
 	}
 	var errs error
 	for _, p := range paths {
-		nodes, err := nodesFromPaths(c, p.String())
+		nodes, err := commoncmd.NodesFromPaths(c, p.String())
 		if err != nil {
 			errors.Join(errs, fmt.Errorf("%s: %w", p, err))
 			continue

--- a/core/oxcmd/object_clear.go
+++ b/core/oxcmd/object_clear.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/opensvc/om3/core/client"
+	"github.com/opensvc/om3/core/commoncmd"
 	"github.com/opensvc/om3/core/naming"
 	"github.com/opensvc/om3/core/objectselector"
 )
@@ -40,7 +41,7 @@ func (t *CmdObjectClear) Run(selector, kind string) error {
 	var todoN int
 
 	for _, path := range paths {
-		nodes, err := nodesFromPaths(c, path.String())
+		nodes, err := commoncmd.NodesFromPaths(c, path.String())
 		if err != nil {
 			errC <- fmt.Errorf("%s: %w", path, err)
 		}

--- a/core/oxcmd/object_logs.go
+++ b/core/oxcmd/object_logs.go
@@ -1,21 +1,8 @@
 package oxcmd
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io"
-	"os"
-	"sync"
-
-	"github.com/opensvc/om3/core/client"
-	"github.com/opensvc/om3/core/naming"
-	"github.com/opensvc/om3/core/nodeselector"
-	"github.com/opensvc/om3/core/objectselector"
-	"github.com/opensvc/om3/core/streamlog"
-	"github.com/opensvc/om3/daemon/api"
+	"github.com/opensvc/om3/core/commoncmd"
 	"github.com/opensvc/om3/util/render"
-	"github.com/opensvc/om3/util/xmap"
 )
 
 type (
@@ -26,93 +13,24 @@ type (
 	}
 )
 
-func (t *CmdObjectLogs) stream(c *client.T, node string, paths naming.Paths) {
-	l := paths.StrSlice()
-	reader, err := c.NewGetLogs(node).
-		SetFilters(&t.Filter).
-		SetLines(&t.Lines).
-		SetFollow(&t.Follow).
-		SetPaths(&l).
-		GetReader()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return
-	}
-	defer reader.Close()
-
-	for {
-		event, err := reader.Read()
-		if errors.Is(err, io.EOF) {
-			break
-		} else if err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-			break
-		}
-		rec, err := streamlog.NewEvent(event.Data)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-			break
-		}
-		rec.Render(t.Output)
-	}
-}
-
-func nodesFromPaths(c *client.T, selector string) ([]string, error) {
-	m := make(map[string]any)
-	params := api.GetObjectsParams{Path: &selector}
-	resp, err := c.GetObjectsWithResponse(context.Background(), &params)
-	if err != nil {
-		return nil, err
-	}
-	if resp.JSON200 == nil {
-		return nil, fmt.Errorf("%s", resp.Status())
-	}
-	for _, item := range resp.JSON200.Items {
-		for node := range item.Data.Instances {
-			m[node] = nil
-		}
-	}
-	return xmap.Keys(m), nil
-}
-
-func (t *CmdObjectLogs) remote(selStr string) error {
-	var (
-		paths naming.Paths
-		nodes []string
-		err   error
-	)
-	c, err := client.New(client.WithTimeout(0))
-	if err != nil {
-		return err
-	}
-	if paths, err = objectselector.New(selStr, objectselector.WithClient(c)).MustExpand(); err != nil {
-		return err
-	}
-	if t.NodeSelector != "" {
-		nodes, err = nodeselector.New(t.NodeSelector, nodeselector.WithClient(c)).Expand()
-		if err != nil {
-			return err
-		}
-	} else {
-		nodes, err = nodesFromPaths(c, selStr)
-		if err != nil {
-			return err
-		}
-	}
-	var wg sync.WaitGroup
-	wg.Add(len(nodes))
-	for _, node := range nodes {
-		go func(n string) {
-			defer wg.Done()
-			t.stream(c, n, paths)
-		}(node)
-	}
-	wg.Wait()
-	return nil
-}
-
 func (t *CmdObjectLogs) Run(selector, kind string) error {
 	render.SetColor(t.Color)
 	mergedSelector := mergeSelector(selector, t.ObjectSelector, kind, "**")
-	return t.remote(mergedSelector)
+	return t.asCommonCmd().Remote(mergedSelector)
+}
+
+func (t *CmdObjectLogs) asCommonCmd() *commoncmd.CmdObjectLogs {
+	return &commoncmd.CmdObjectLogs{
+		OptsGlobal: commoncmd.OptsGlobal{
+			Color:          t.Color,
+			Output:         t.Output,
+			ObjectSelector: t.ObjectSelector,
+		},
+		OptsLogs: commoncmd.OptsLogs{
+			Follow: t.Follow,
+			Lines:  t.Lines,
+			Filter: t.Filter,
+		},
+		NodeSelector: t.NodeSelector,
+	}
 }

--- a/core/streamlog/main.go
+++ b/core/streamlog/main.go
@@ -9,9 +9,10 @@ import (
 	"sort"
 
 	"github.com/fatih/color"
+	"github.com/rs/zerolog"
+
 	"github.com/opensvc/om3/core/rawconfig"
 	"github.com/opensvc/om3/util/command"
-	"github.com/rs/zerolog"
 )
 
 type (
@@ -32,15 +33,15 @@ type (
 	Events []Event
 )
 
-func (event Event) Map() map[string]any {
+func (event *Event) Map() map[string]any {
 	return event.M
 }
 
-func (event Event) IsZero() bool {
+func (event *Event) IsZero() bool {
 	return event.M == nil
 }
 
-func (event Event) RenderConsole() {
+func (event *Event) RenderConsole() {
 	w := zerolog.NewConsoleWriter()
 	w.TimeFormat = "2006-01-02T15:04:05.000Z07:00"
 	w.NoColor = color.NoColor
@@ -55,11 +56,11 @@ func (event Event) RenderConsole() {
 	}
 }
 
-func (event Event) RenderData() {
+func (event *Event) RenderData() {
 	fmt.Printf("%s\n", string(event.B))
 }
 
-func (event Event) Render(format string) {
+func (event *Event) Render(format string) {
 	switch format {
 	case "json":
 		event.RenderData()
@@ -147,17 +148,17 @@ func NewStream() *Stream {
 	}
 }
 
-func (stream Stream) Errors() chan error {
+func (stream *Stream) Errors() chan error {
 	return stream.errs
 }
 
-func (stream Stream) Events() chan Event {
+func (stream *Stream) Events() chan Event {
 	return stream.q
 }
 
 func (stream *Stream) Stop() error {
 	if c := stream.cmd.Cmd(); c != nil {
-		c.Process.Kill()
+		_ = c.Process.Kill()
 	}
 	return nil
 }
@@ -190,7 +191,7 @@ func (stream *Stream) Start(streamConfig StreamConfig) error {
 		return err
 	}
 	go func() {
-		stream.cmd.Wait()
+		_ = stream.cmd.Wait()
 		stream.errs <- nil // signal client we are done sending
 	}()
 	return nil

--- a/core/streamlog/main.go
+++ b/core/streamlog/main.go
@@ -137,7 +137,11 @@ func NewEvent(b []byte) (Event, error) {
 	if err := json.Unmarshal(b, &m); err != nil {
 		return Event{}, err
 	} else {
-		return Event{B: b, M: m}, nil
+		if len(b) > 0 && b[len(b)-1] == '\n' {
+			return Event{B: b[:len(b)-1], M: m}, nil
+		} else {
+			return Event{B: b, M: m}, nil
+		}
 	}
 }
 


### PR DESCRIPTION
### Description

This pull request contains the following updates:

1. **Shared Command Functionality**:
   - Introduced a shared `core/commoncmd` package for `omcmd` and `oxcmd` commands.
   - Updated command implementations to use the shared functionality.
   - Fixed the ignored `--node` option in `om node log` command.

2. **Stream Log Enhancements**:
   - Fixed newline handling in event rendering and unmarshalling for consistency.
   - Refactored methods in `Event` and `Stream` structs to use pointer receivers for efficiency.
   - Removed redundant newline in the JSON renderer.
     This improves output of `ox node log -o json | hl -P -h '*' -h '!node'`. 


3. **Event Handling Improvements**:
   - Improved error handling for process termination.
   - Handled unexpected `nil` values in event and error channels gracefully, avoiding potential runtime errors.
