### PR TITLE
Stop exiting om commands on cluster config errors

### DIFF
--- a/core/cluster/config.go
+++ b/core/cluster/config.go
@@ -11,6 +11,7 @@ type (
 	// The cluster name is used as the right most part of cluster dns
 	// names.
 	Config struct {
+		Issues     []string       `json:"issues"`
 		ID         string         `json:"id"`
 		Name       string         `json:"name"`
 		Nodes      Nodes          `json:"nodes"`

--- a/core/object/ccfg.go
+++ b/core/object/ccfg.go
@@ -129,20 +129,19 @@ func getClusterConfig() (*cluster.Config, error) {
 	cfg.CASecPaths = c.GetStrings(keyCASecPaths)
 	cfg.SetSecret(c.GetString(keySecret))
 	cfg.Quorum = c.GetBool(keyQuorum)
-	var errs error
 	if vip, err := getVip(c, cfg.Nodes); err != nil {
-		errs = errors.Join(errs, err)
+		cfg.Issues = append(cfg.Issues, err.Error())
 	} else {
 		cfg.Vip = vip
 	}
 	cfg.Listener.CRL = c.GetString(keyListenerCRL)
 	if v, err := c.Eval(keyListenerAddr); err != nil {
-		errs = errors.Join(errs, fmt.Errorf("eval listener addr: %s", err))
+		cfg.Issues = append(cfg.Issues, fmt.Sprintf("eval listener addr: %s", err))
 	} else {
 		cfg.Listener.Addr = v.(string)
 	}
 	if v, err := c.Eval(keyListenerPort); err != nil {
-		errs = errors.Join(errs, fmt.Errorf("eval listener port: %s", err))
+		cfg.Issues = append(cfg.Issues, fmt.Sprintf("eval listener port: %s", err))
 	} else {
 		cfg.Listener.Port = v.(int)
 	}
@@ -150,11 +149,11 @@ func getClusterConfig() (*cluster.Config, error) {
 	cfg.Listener.DNSSockGID = c.GetString(keyListenerDNSSockGID)
 	cfg.Listener.DNSSockUID = c.GetString(keyListenerDNSSockUID)
 	if homedir, err := os.UserHomeDir(); err != nil {
-		errs = errors.Join(errs, fmt.Errorf("user home dir: %s", err))
+		cfg.Issues = append(cfg.Issues, fmt.Sprintf("user home dir: %s", err))
 	} else {
 		cfg.SetSSHKeyFile(filepath.Join(homedir, ".ssh", c.GetString(keyNodeSSHKey)))
 	}
-	return cfg, errs
+	return cfg, nil
 }
 
 var (

--- a/daemon/ccfg/main_cmd.go
+++ b/daemon/ccfg/main_cmd.go
@@ -1,7 +1,6 @@
 package ccfg
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/opensvc/om3/core/cluster"
@@ -24,13 +23,11 @@ func (t *Manager) onConfigFileUpdated(c *msgbus.ConfigFileUpdated) {
 func (t *Manager) pubClusterConfig() {
 	previousNodes := t.state.Nodes
 	state, err := object.SetClusterConfig()
-	switch {
-	case err == nil:
-	case errors.Is(err, object.ErrVIPScope):
-		t.log.Warnf("%s", err)
-	default:
+	if err != nil {
 		t.log.Errorf("%s", err)
-
+	}
+	for _, issue := range state.Issues {
+		t.log.Warnf("issue: %s", issue)
 	}
 	t.handleConfigChanges()
 

--- a/daemon/daemoncmd/main.go
+++ b/daemon/daemoncmd/main.go
@@ -108,7 +108,7 @@ func bootStrapCcfg() error {
 		if k.Obfuscate {
 			op.Value = "xxxx"
 		}
-		log.Infof("bootstrap cluster config: %s", op)
+		log.Infof("%s", op)
 	}
 
 	// Prepares futures node join, because it requires at least one heartbeat.
@@ -126,14 +126,18 @@ func bootStrapCcfg() error {
 		if err := ccfg.Config().PrepareSet(*op); err != nil {
 			return err
 		}
-		log.Infof("bootstrap cluster config to have at least one heartbeat: %s", op)
+		log.Infof("add default heartbeat: %s", op)
 	}
 
 	if err := ccfg.Config().Commit(); err != nil {
 		return err
 	}
-	if _, err := object.SetClusterConfig(); err != nil {
-		log.Errorf("bootstrap cluster config: set cluster config: %s", err)
+	if cfg, err := object.SetClusterConfig(); err != nil {
+		return err
+	} else {
+		for _, issue := range cfg.Issues {
+			log.Warnf("issue: %s", issue)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
So troubleshooting commands like "om mon", "om cluster set", "om cluster ed", "om cluster get" can still be used.

* Add a Issues field in cluster.Config, report issues there instead of mixing errors and issues in the error returned by object.getCluterConfig()

* Ignore issues from the om commands PersistentPreRunE()

* Log warning from Issues in the deamoncmd ccfg bootstrap and from the cluster config file event handler, so issues don't go unnoticed.