### PR TITLE
Refactored heartbeat disk operations to enhance slot management

### DIFF
--- a/core/object/node_keywords.go
+++ b/core/object/node_keywords.go
@@ -697,6 +697,15 @@ var nodeCommonKeywords = []keywords.Keyword{
 		Types:    []string{"disk"},
 	},
 	{
+		Converter: converters.Int,
+		Example:   "64",
+		Default:   "64",
+		Option:    "max_slots",
+		Section:   "hb",
+		Text:      keywords.NewText(fs, "text/kw/node/hb.disk.max_slots"),
+		Types:     []string{"disk"},
+	},
+	{
 		Converter: converters.Bool,
 		Default:   "false",
 		Option:    "insecure",

--- a/core/object/text/kw/node/hb.disk.max_slots
+++ b/core/object/text/kw/node/hb.disk.max_slots
@@ -1,0 +1,3 @@
+The maximum number of slots that can be written to the HB disk device.
+
+It should be set to at least twice the number of cluster nodes using the HB disk device.

--- a/core/xconfig/validate.go
+++ b/core/xconfig/validate.go
@@ -304,9 +304,9 @@ func (t T) Validate() (Alerts, error) {
 			}
 			if len(kw.Candidates) > 0 {
 				switch kw.Converter {
-				case nil:
+				case nil,
+					converters.Int:
 					if !slices.Contains(kw.Candidates, v) {
-
 						alerts = append(alerts, t.NewAlertCandidates(k, did, v))
 					}
 				case converters.List:

--- a/daemon/daemonapi/get_node_ssh_key.go
+++ b/daemon/daemonapi/get_node_ssh_key.go
@@ -3,6 +3,7 @@ package daemonapi
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -40,9 +41,13 @@ func (a *DaemonAPI) getLocalSSHKey(ctx echo.Context) error {
 	pubFile := filepath.Join(homeDir, ".ssh", nodeConfig.SSHKey+".pub")
 	data, err := os.ReadFile(pubFile)
 	if errors.Is(err, os.ErrNotExist) {
+		args := []string{
+			"-N", "", "-q", "-f", keyFile,
+			"-C", fmt.Sprintf("opensvc-cluster-root-trust@%s", a.localhost),
+		}
 		err = command.New(
 			command.WithName("ssh-keygen"),
-			command.WithVarArgs("-N", "", "-q", "-f", keyFile),
+			command.WithArgs(args),
 			command.WithLogger(log),
 			command.WithCommandLogLevel(zerolog.InfoLevel),
 			command.WithStderrLogLevel(zerolog.ErrorLevel),

--- a/daemon/daemonapi/put_node_ssh_trust.go
+++ b/daemon/daemonapi/put_node_ssh_trust.go
@@ -130,9 +130,6 @@ func (a *DaemonAPI) localPutNodeSSHTrust(ctx echo.Context) error {
 
 	var errs error
 	for _, node := range clusterConfigData.Nodes {
-		if node == a.localhost {
-			continue
-		}
 		if err := doNode(node); err != nil {
 			errs = errors.Join(errs, err)
 		}

--- a/daemon/daemondata/data.go
+++ b/daemon/daemondata/data.go
@@ -281,11 +281,8 @@ func (d *data) run(ctx context.Context, cmdC <-chan Caller, hbRecvQ <-chan *hbty
 				if isCtxDone() {
 					return
 				}
-				gens := make(node.Gen)
-				for s, v := range *lgens {
-					gens[s] = v
-				}
-				d.publisher.Pub(&msgbus.NodeStatusGenUpdates{Node: d.localNode, Value: gens},
+				node.GenData.Set(d.localNode, d.msgLocalGen.DeepCopy())
+				d.publisher.Pub(&msgbus.NodeStatusGenUpdates{Node: d.localNode, Value: *d.msgLocalGen.DeepCopy()},
 					d.labelLocalhost,
 				)
 			}

--- a/daemon/hb/hbctrl/main.go
+++ b/daemon/hb/hbctrl/main.go
@@ -93,6 +93,12 @@ type (
 		result chan<- EventStats
 	}
 
+	// CmdSetAlert is a command to post new hb alert
+	CmdSetAlert struct {
+		HbID  string
+		Alert []daemonsubsystem.Alert
+	}
+
 	// CmdSetPeerSuccess is a command to set a hb peer success value for a node
 	CmdSetPeerSuccess struct {
 		Nodename string
@@ -213,6 +219,7 @@ func (c *C) run() {
 					Status: heartbeat[key].Status,
 					Type:   heartbeat[key].Type,
 					Peers:  peers,
+					Alerts: append([]daemonsubsystem.Alert(nil), heartbeat[key].Alerts...),
 				})
 			}
 			hbcache.SetHeartbeats(heartbeats)
@@ -304,6 +311,12 @@ func (c *C) run() {
 					o.result <- foundHeartbeat.Peers
 				} else {
 					o.result <- make(map[string]daemonsubsystem.HeartbeatStreamPeerStatus)
+				}
+			case CmdSetAlert:
+				hbID := o.HbID
+				if foundHeartbeat, ok := heartbeat[hbID]; ok {
+					foundHeartbeat.Alerts = append([]daemonsubsystem.Alert(nil), o.Alert...)
+					heartbeat[hbID] = foundHeartbeat
 				}
 			case CmdSetPeerStatus:
 				hbID := o.HbID

--- a/daemon/hb/hbdisk/device.go
+++ b/daemon/hb/hbdisk/device.go
@@ -1,0 +1,195 @@
+package hbdisk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ncw/directio"
+
+	"github.com/opensvc/om3/util/file"
+)
+
+type (
+	device struct {
+		mode string
+		path string
+		file *os.File
+	}
+)
+
+const (
+	// openDevicePermission is the permission used for open device file
+	openDevicePermission = 0755
+
+	// modeDirectIO is the mode for Linux Direct IO
+	modeDirectIO = "directio"
+
+	// modeRaw is the mode for non-Linux systems
+	modeRaw = "raw" // Mode for non-Linux systems
+)
+
+// calculateMetaSlotOffset returns the offset of the meta page of the slot.
+func (t *device) calculateMetaSlotOffset(slot int) int64 {
+	return pageSizeInt64 * int64(slot)
+}
+
+func (t *device) readMetaSlot(slot int) ([]byte, error) {
+	offset := t.calculateMetaSlotOffset(slot)
+	if _, err := t.file.Seek(offset, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seek offset %d: %w", offset, err)
+	}
+	block := directio.AlignedBlock(PageSize)
+	if _, err := io.ReadFull(t.file, block); err != nil {
+		return nil, fmt.Errorf("read full at offset %d: %w", offset, err)
+	}
+	return block, nil
+}
+
+func (t *device) writeMetaSlot(slot int, b []byte) error {
+	if len(b) > PageSize {
+		return fmt.Errorf("attempt to write too long data in meta slot %d", slot)
+	}
+	offset := t.calculateMetaSlotOffset(slot)
+	if _, err := t.file.Seek(offset, io.SeekStart); err != nil {
+		return fmt.Errorf("seek offset %d: %w", offset, err)
+	}
+	block := directio.AlignedBlock(PageSize)
+	copy(block, b)
+	if _, err := t.file.Write(block); err != nil {
+		fmt.Errorf("write at offset %d: %w", offset, err)
+	}
+	return nil
+}
+
+// calculateDataSlotOffset calculates the byte offset of a data slot within the storage device.
+func (t *device) calculateDataSlotOffset(slot int) int64 {
+	return MetaSizeInt64 + SlotSizeInt64*int64(slot)
+}
+
+func (t *device) readDataSlot(slot int) (capsule, error) {
+	c := capsule{}
+	offset := t.calculateDataSlotOffset(slot)
+	if _, err := t.file.Seek(offset, io.SeekStart); err != nil {
+		return c, fmt.Errorf("seek offset %d: %w", offset, err)
+	}
+	data := make([]byte, 0)
+	totalRead := 0
+	for {
+		block := directio.AlignedBlock(PageSize)
+		n, err := io.ReadFull(t.file, block)
+		totalRead += n
+		if err != nil {
+			return c, fmt.Errorf("read full at offset %d: %w", offset, err)
+		}
+		if n == 0 {
+			break
+		}
+		i := bytes.IndexRune(block, endOfDataMarker)
+		if i < 0 {
+			data = append(data, block...)
+		} else {
+			data = append(data, block[:i]...)
+			break
+		}
+		if totalRead >= SlotSize {
+			break
+		}
+	}
+	if err := json.Unmarshal(data, &c); err != nil {
+		return c, fmt.Errorf("unmarshall from offset %d :%w", slot, err)
+	}
+	return c, nil
+}
+
+func (t *device) writeDataSlot(slot int, b []byte) error {
+	c := capsule{
+		Msg:     b,
+		Updated: time.Now(),
+	}
+	b, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("msg encapsulation: %w", err)
+	}
+	b = append(b, []byte{endOfDataMarker}...)
+	if len(b) > SlotSize {
+		return fmt.Errorf("attempt to write too long data in data slot %d", slot)
+	}
+	offset := t.calculateDataSlotOffset(slot)
+	if _, err := t.file.Seek(offset, io.SeekStart); err != nil {
+		return fmt.Errorf("seek offset %d: %w", offset, err)
+	}
+	remaining := len(b)
+	for {
+		if remaining == 0 {
+			break
+		}
+		block := directio.AlignedBlock(PageSize)
+		copied := copy(block, b)
+		if _, err := t.file.Write(block); err != nil {
+			return fmt.Errorf("write at offset %d: %w", offset, err)
+		}
+		if copied < PageSize {
+			return nil
+		}
+		b = b[copied:]
+		remaining -= copied
+	}
+	return nil
+}
+
+func (t *device) open() error {
+	if t.path == "" {
+		return fmt.Errorf("the 'dev' keyword is not set")
+	}
+
+	newDev, err := validateDevice(t.path)
+	if err != nil {
+		return err
+	}
+
+	return t.openDevice(newDev)
+}
+
+// ensureBlockDevice checks if the specified device path refers to a valid
+// block device and returns an error if it is not.
+func (t *device) ensureBlockDevice(path string) error {
+	if ok, err := file.IsBlockDevice(path); err != nil {
+		return fmt.Errorf("%s must be a block device: %w", path, err)
+	} else if !ok {
+		return fmt.Errorf("%s must be a block device", path)
+	}
+	return nil
+}
+
+// ensureBlockDevice checks if the specified device path refers to a valid
+// char device and returns an error if it is not.
+func (t *device) ensureCharDevice(path string) error {
+	if ok, err := file.IsCharDevice(path); err != nil {
+		return fmt.Errorf("%s must be a char device: %w", path, err)
+	} else if !ok {
+		return fmt.Errorf("%s must be a char device", path)
+	}
+	return nil
+}
+
+// validateDevice resolves symlinks for the given path and ensures the target
+// device exists, returning its resolved path.
+// Returns an error if the path is invalid, the device does not exist,
+// or other filesystem issues occur.
+func validateDevice(path string) (string, error) {
+	newPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("%s eval symlink: %w", path, err)
+	}
+	if _, err := os.Stat(newPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("%s does not exist: %w", path, err)
+	} else if err != nil {
+		return "", err
+	}
+	return newPath, nil
+}

--- a/daemon/hb/hbdisk/device_dummy.go
+++ b/daemon/hb/hbdisk/device_dummy.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package hbdisk
+
+// openDevice opens the specified char device, validates it, and
+// initializes file handling for raw mode operations.
+func (t *device) openDevice(newDev string) error {
+	if err := t.ensureCharDevice(newDev); err != nil {
+		return err
+	}
+	t.mode = modeRaw
+	if t.file, err = os.OpenFile(t.path, os.O_RDWR, openDevicePermission); err != nil {
+		return fmt.Errorf("%s open char device: %w", t.path, err)
+	}
+}

--- a/daemon/hb/hbdisk/device_linux.go
+++ b/daemon/hb/hbdisk/device_linux.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package hbdisk
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/ncw/directio"
+)
+
+// openDevice opens the specified block device in Direct IO mode.
+// It validates that the path follows a static naming convention for safety and
+// returns an error on failure.
+func (t *device) openDevice(newDev string) error {
+	if strings.HasPrefix("/dev/dm-", t.path) {
+		return fmt.Errorf("%s is not static enough a name to allow. please use a /dev/mapper/<name> or /dev/by-<attr>/<value> dev path", t.path)
+	}
+	if strings.HasPrefix("/dev/sd", t.path) {
+		return fmt.Errorf("%s is not a static name. using a /dev/mapper/<name> or /dev/by-<attr>/<value> dev path is safer", t.path)
+	}
+
+	err := t.ensureBlockDevice(newDev)
+	if err != nil {
+		return err
+	}
+	t.mode = modeDirectIO
+	if t.file, err = directio.OpenFile(newDev, os.O_RDWR|os.O_SYNC|syscall.O_DSYNC, openDevicePermission); err != nil {
+		return fmt.Errorf("%s directio open block device: %w", newDev, err)
+	}
+	return nil
+}

--- a/daemon/hb/hbdisk/hbrx.go
+++ b/daemon/hb/hbdisk/hbrx.go
@@ -195,6 +195,10 @@ func (t *rx) rescanMetadata(reason string) {
 		t.log.Infof("rescan metadata: %s", err)
 		t.alert = append(t.alert, daemonsubsystem.Alert{Severity: "warning", Message: reason})
 	}
+	if len(t.base.nodeSlotUnknown) > 0 {
+		msg := fmt.Sprintf("nodes without slot: %s", maps.Keys(t.base.nodeSlotUnknown))
+		t.alert = append(t.alert, daemonsubsystem.Alert{Severity: "warning", Message: msg})
+	}
 	t.updateAlertWithSlots()
 	t.sendAlert()
 }

--- a/daemon/hb/hbdisk/hbrx.go
+++ b/daemon/hb/hbdisk/hbrx.go
@@ -61,7 +61,7 @@ func (t *rx) Start(cmdC chan<- any, msgC chan<- *hbtype.Msg) error {
 	if err := t.base.device.open(); err != nil {
 		return err
 	}
-	if err := t.base.LoadPeerConfig(t.nodes); err != nil {
+	if err := t.base.loadPeerConfig(t.nodes); err != nil {
 		return err
 	}
 	ctx, cancel := context.WithCancel(t.ctx)
@@ -112,12 +112,12 @@ func (t *rx) onTick() {
 }
 
 func (t *rx) recv(nodename string) {
-	meta, err := t.base.GetPeer(nodename)
+	meta, err := t.base.getPeer(nodename)
 	if err != nil {
 		t.log.Debugf("recv: failed to allocate a slot for node %s: %s", nodename, err)
 		return
 	}
-	c, err := t.base.ReadDataSlot(meta.Slot) // TODO read timeout?
+	c, err := t.base.readDataSlot(meta.Slot) // TODO read timeout?
 	if err != nil {
 		t.log.Debugf("recv: reading node %s data slot %d: %s", nodename, meta.Slot, err)
 		return

--- a/daemon/hb/hbdisk/hbtx.go
+++ b/daemon/hb/hbdisk/hbtx.go
@@ -55,7 +55,7 @@ func (t *tx) Start(cmdC chan<- interface{}, msgC <-chan []byte) error {
 	if err := t.base.device.open(); err != nil {
 		return err
 	}
-	if err := t.base.LoadPeerConfig(t.nodes); err != nil {
+	if err := t.base.loadPeerConfig(t.nodes); err != nil {
 		return err
 	}
 	reasonTick := fmt.Sprintf("send msg (interval %s)", t.interval)
@@ -102,13 +102,13 @@ func (t *tx) Start(cmdC chan<- interface{}, msgC <-chan []byte) error {
 }
 
 func (t *tx) send(b []byte) {
-	meta, err := t.base.GetPeer(hostname.Hostname())
+	meta, err := t.base.getPeer(hostname.Hostname())
 	if err != nil {
 		t.log.Debugf("send can't get peer for localhost: %s", err)
 		return
 	}
-	if t.base.WriteDataSlot(meta.Slot, b); err != nil { // TODO write timeout?
-		t.log.Debugf("send can't write data slot: %s", err)
+	if err := t.base.writeDataSlot(meta.Slot, b); err != nil { // TODO write timeout?
+		t.log.Debugf("send can't write data slot %d: %s", meta.Slot, err)
 		return
 	} else {
 		t.log.Debugf("send wrote to slot %d %s", meta.Slot, string(b))

--- a/daemon/hb/hbdisk/main.go
+++ b/daemon/hb/hbdisk/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ncw/directio"
 
 	"github.com/opensvc/om3/core/hbcfg"
+	"github.com/opensvc/om3/daemon/daemonsubsystem"
 	"github.com/opensvc/om3/util/hostname"
 	"github.com/opensvc/om3/util/key"
 	"github.com/opensvc/om3/util/plog"
@@ -183,4 +184,13 @@ func nodeFromMetadata(b []byte) string {
 
 func metaSize(maxSlots int) int64 {
 	return int64(maxSlots * PageSize)
+}
+
+func getSlotAlert(nodename string, slot int) daemonsubsystem.Alert {
+	msg := fmt.Sprintf("node %s slot %d", nodename, slot)
+	level := "info"
+	if slot < 0 {
+		level = "warning"
+	}
+	return daemonsubsystem.Alert{Severity: level, Message: msg}
 }

--- a/daemon/hb/hbdisk/main.go
+++ b/daemon/hb/hbdisk/main.go
@@ -125,7 +125,12 @@ func (t *base) loadPeerConfig(nodes []string) error {
 		if err != nil {
 			return fmt.Errorf("read meta slot %d: %w", slot, errors.Join(errs, err))
 		}
-		nodename := string(b[:bytes.IndexRune(b, '\x00')])
+		index := bytes.IndexRune(b, endOfDataMarker)
+		if index < 0 {
+			// ignore corrupted meta slot
+			continue
+		}
+		nodename := string(b[:index])
 		data, ok := t.peerConfigs[nodename]
 		if !ok {
 			// foreign node

--- a/daemon/hb/main.go
+++ b/daemon/hb/main.go
@@ -501,6 +501,9 @@ func (t *T) janitor(ctx context.Context) {
 						t.daemonCtlStop(hbID, action)
 					case "start":
 						t.daemonCtlStart(t.ctx, hbID, action)
+					case "restart":
+						t.daemonCtlStop(hbID, action)
+						t.daemonCtlStart(t.ctx, hbID, action)
 					}
 				}
 			}

--- a/daemon/hb/main.go
+++ b/daemon/hb/main.go
@@ -168,10 +168,10 @@ func (t *T) stopHb(hb hbtype.IDStopper) error {
 
 func (t *T) startHb(hb hbcfg.Confer) error {
 	var errs error
-	if err := t.startHbRx(hb); err != nil {
+	if err := t.startHbTx(hb); err != nil {
 		errs = errors.Join(errs, err)
 	}
-	if err := t.startHbTx(hb); err != nil {
+	if err := t.startHbRx(hb); err != nil {
 		errs = errors.Join(errs, err)
 	}
 	return errs


### PR DESCRIPTION
### Description

This pull request includes the following changes:

- **Command Enhancements:**
  - Updated the `om cluster ssh trust` command to trust localhost in addition to peer nodes.
  - Improved the SSH key comment format to include the `opensvc-cluster-root-trust@<nodename>` structure for better clarity.

- **Bug Fixes:**
  - Addressed issues with unexpected `NodeStatusGenUpdates` publications in `daemondata`.

- **Improvements:**
  - Incorporated a validation mechanism to handle `converters.Int` during keyword candidate checks, ensuring alerts are raised for mismatched values.
  - Refactored heartbeat disk operations to enhance slot management and improve logging for easier debugging.
