### PR TITLE
Add a "om daemon run" command to replace "start --foreground"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,6 +421,8 @@ Where the password is the value of the `þassword` key in `system/sec/relay-v3`.
 
 ### Daemon
 
+* The daemon process name is changed from `/usr/bin/python3 -m opensvc.daemon` to `om daemon run`. Monitoring checks may need to adapt.
+
 * Add a 60 seconds timeout to `pre_monitor_action`. The 2.1 daemon waits forever for this callout to terminate.
 
 * Earlier local object instance orchestration after node boot

--- a/core/om/daemon.go
+++ b/core/om/daemon.go
@@ -39,6 +39,7 @@ func init() {
 		newCmdDaemonLeave(),
 		cmdDaemonRelay,
 		newCmdDaemonRestart(),
+		newCmdDaemonRun(),
 		newCmdDaemonRunning(),
 		newCmdDaemonShutdown(),
 		newCmdDaemonStart(),

--- a/core/om/factory.go
+++ b/core/om/factory.go
@@ -332,6 +332,23 @@ func newCmdDaemonRestart() *cobra.Command {
 	return cmd
 }
 
+func newCmdDaemonRun() *cobra.Command {
+	var options commands.CmdDaemonRun
+	cmd := &cobra.Command{
+		Use:     "run",
+		Short:   "run the daemon in foreground",
+		Long:    "Start executes a detached run",
+		Aliases: []string{"star"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return options.Run()
+		},
+	}
+	flags := cmd.Flags()
+	addFlagsGlobal(flags, &options.OptsGlobal)
+	addFlagCPUProfile(flags, &options.CPUProfile)
+	return cmd
+}
+
 func newCmdDaemonRunning() *cobra.Command {
 	var options commands.CmdDaemonRunning
 	cmd := &cobra.Command{
@@ -376,7 +393,6 @@ func newCmdDaemonStart() *cobra.Command {
 	}
 	flags := cmd.Flags()
 	addFlagsGlobal(flags, &options.OptsGlobal)
-	addFlagForeground(flags, &options.Foreground)
 	addFlagCPUProfile(flags, &options.CPUProfile)
 	return cmd
 }
@@ -1164,7 +1180,7 @@ func newCmdNodeEvents() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "events",
 		Short:   "print the node event stream",
-		Long:    "print the node event stream\n\nAvailable kinds: \n" + eventKindTemplate,
+		Long:    "Print the node event stream\n\nAvailable kinds: \n" + eventKindTemplate,
 		Aliases: []string{"eve", "even", "event"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return options.Run()
@@ -2230,7 +2246,7 @@ func newCmdObjectDelete(kind string) *cobra.Command {
 		Use:     "delete",
 		Aliases: []string{"del"},
 		Short:   "delete configuration object or instances (with --local)",
-		Long: "delete configuration object or instances (with --local)\n\n" +
+		Long: "Delete configuration object or instances (with --local)\n\n" +
 			"Beware: --local only removes the local instance config." +
 			" The config may be recreated by the daemon from a remote instance copy." +
 			" Without --local the delete is orchestrated so all instance configurations" +

--- a/core/om/flags.go
+++ b/core/om/flags.go
@@ -168,10 +168,6 @@ func addFlagEventFilters(flagSet *pflag.FlagSet, p *[]string) {
 	flagSet.StringArrayVar(p, "filter", []string{}, usageFlagEventFilter)
 }
 
-func addFlagForeground(flagSet *pflag.FlagSet, p *bool) {
-	flagSet.BoolVarP(p, "foreground", "f", false, "Restart the daemon in foreground mode.")
-}
-
 func addFlagForce(flagSet *pflag.FlagSet, p *bool) {
 	flagSet.BoolVar(p, "force", false, "Allow dangerous operations.")
 }

--- a/core/omcmd/daemon_run.go
+++ b/core/omcmd/daemon_run.go
@@ -8,17 +8,17 @@ import (
 )
 
 type (
-	CmdDaemonStart struct {
+	CmdDaemonRun struct {
 		OptsGlobal
 		CPUProfile string
 	}
 )
 
-func (t *CmdDaemonStart) Run() error {
+func (t *CmdDaemonRun) Run() error {
 	cli, err := client.New()
 	if err != nil {
 		return err
 	}
 	ctx := context.Background()
-	return daemoncmd.NewContext(ctx, cli).StartFromCmd(ctx, false, t.CPUProfile)
+	return daemoncmd.NewContext(ctx, cli).StartFromCmd(ctx, true, t.CPUProfile)
 }

--- a/core/ox/flags.go
+++ b/core/ox/flags.go
@@ -135,10 +135,6 @@ func addFlagEventFilters(flagSet *pflag.FlagSet, p *[]string) {
 	flagSet.StringArrayVar(p, "filter", []string{}, usageFlagEventFilter)
 }
 
-func addFlagForeground(flagSet *pflag.FlagSet, p *bool) {
-	flagSet.BoolVarP(p, "foreground", "f", false, "Restart the daemon in foreground mode.")
-}
-
 func addFlagForce(flagSet *pflag.FlagSet, p *bool) {
 	flagSet.BoolVar(p, "force", false, "Allow dangerous operations.")
 }

--- a/daemon/daemoncmd/main.go
+++ b/daemon/daemoncmd/main.go
@@ -248,17 +248,19 @@ func (t *T) StartFromCmd(ctx context.Context, foreground bool, profile string) e
 	}
 	if t.daemonsys.CalledFromManager() {
 		if foreground {
-			log.Infof("foreground (origin manager)")
+			// Type=simple unit (expected)
+			log.Infof("run (origin manager)")
 			return t.startFromCmd(foreground, profile)
 		}
+		// Type=forking unit
 		if isRunning, err := t.isRunning(); err != nil {
 			return err
 		} else if isRunning {
 			log.Infof("already running (origin manager)")
 			return nil
 		}
-		log.Infof("run new cmd --foreground (origin manager)")
-		args := []string{"daemon", "start", "--foreground"}
+		log.Infof("exec run (origin manager)")
+		args := []string{"daemon", "run"}
 		cmd := command.New(
 			command.WithName(os.Args[0]),
 			command.WithArgs(args),
@@ -519,10 +521,7 @@ func (t *T) startFromCmd(foreground bool, profile string) error {
 			}
 			return nil
 		}
-		args := []string{"daemon", "start", "--foreground"}
-		if t.daemonsys == nil {
-			args = append(args, "--native")
-		}
+		args := []string{"daemon", "run"}
 		cmd := command.New(
 			command.WithName(os.Args[0]),
 			command.WithArgs(args),


### PR DESCRIPTION
So the daemon long-standing process name doesn't confuse the user into thinking the daemon is still starting.