### PR TITLE
Allow rootless "om cluster doc" and "om node doc"

### DIFF
--- a/core/object/core.go
+++ b/core/object/core.go
@@ -86,6 +86,7 @@ func (t *core) List() (string, error) {
 }
 
 func (t *core) init(referrer xconfig.Referrer, path naming.Path, opts ...funcopt.O) error {
+	t.configFile = t.path.ConfigFile()
 	if err := funcopt.Apply(t, opts...); err != nil {
 		return err
 	}
@@ -118,9 +119,6 @@ func (t *core) Path() naming.Path {
 // ConfigFile returns the absolute path of an opensvc object configuration
 // file.
 func (t *core) ConfigFile() string {
-	if t.configFile == "" {
-		t.configFile = t.path.ConfigFile()
-	}
 	return t.configFile
 }
 

--- a/core/object/core_config.go
+++ b/core/object/core_config.go
@@ -35,15 +35,14 @@ func (t *core) reloadConfig() error {
 func (t *core) loadConfig(referrer xconfig.Referrer) error {
 	var err error
 	var sources []any
-	cf := t.ConfigFile()
 	if t.configData != nil {
 		sources = []any{t.configData}
-	} else if cf != "" {
-		sources = []any{cf}
+	} else if t.configFile != "" {
+		sources = []any{t.configFile}
 	} else {
 		sources = []any{}
 	}
-	if t.config, err = xconfig.NewObject(cf, sources...); err != nil {
+	if t.config, err = xconfig.NewObject(t.configFile, sources...); err != nil {
 		return err
 	}
 	t.config.Path = t.path

--- a/core/object/factory.go
+++ b/core/object/factory.go
@@ -14,8 +14,25 @@ var ErrWrongType = errors.New("wrong type provided for interface")
 // WithConfigFile sets a non-standard configuration location.
 func WithConfigFile(s string) funcopt.O {
 	return funcopt.F(func(t any) error {
-		o := t.(*core)
-		o.configFile = s
+		if o, ok := t.(*core); ok {
+			o.configFile = s
+		} else if o, ok := t.(*Node); ok {
+			o.configFile = s
+		} else {
+			return fmt.Errorf("WithConfigFile() is not supported on %v", t)
+		}
+		return nil
+	})
+}
+
+// WithConfigFile sets a non-standard configuration location.
+func WithClusterConfigFile(s string) funcopt.O {
+	return funcopt.F(func(t any) error {
+		if o, ok := t.(*Node); ok {
+			o.clusterConfigFile = s
+		} else {
+			return fmt.Errorf("WithClusterConfigFile() is not supported on %v", t)
+		}
 		return nil
 	})
 }

--- a/core/object/node.go
+++ b/core/object/node.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/opensvc/om3/core/rawconfig"
 	"github.com/opensvc/om3/core/xconfig"
 	"github.com/opensvc/om3/util/funcopt"
 	"github.com/opensvc/om3/util/plog"
@@ -17,18 +18,22 @@ type (
 		volatile bool
 
 		// caches
-		id           uuid.UUID
-		configData   any
-		configFile   string
-		config       *xconfig.T
-		mergedConfig *xconfig.T
-		paths        nodePaths
+		id                uuid.UUID
+		configData        any
+		configFile        string
+		clusterConfigFile string
+		config            *xconfig.T
+		mergedConfig      *xconfig.T
+		paths             nodePaths
 	}
 )
 
 // NewNode allocates a node.
 func NewNode(opts ...funcopt.O) (*Node, error) {
-	t := &Node{}
+	t := &Node{
+		configFile:        rawconfig.NodeConfigFile(),
+		clusterConfigFile: rawconfig.ClusterConfigFile(),
+	}
 	if err := t.init(opts...); err != nil {
 		return nil, err
 	}

--- a/core/object/node_config.go
+++ b/core/object/node_config.go
@@ -23,32 +23,34 @@ func (t Node) Exists() bool {
 }
 
 func (t *Node) ConfigFile() string {
-	return rawconfig.NodeConfigFile()
+	return t.configFile
 }
 
 func (t *Node) ClusterConfigFile() string {
-	return rawconfig.ClusterConfigFile()
+	return t.clusterConfigFile
 }
 
 func (t *Node) loadConfig() error {
 	var sources []any
-	nodeConfigFile := t.ConfigFile()
 
 	if t.configData != nil {
 		sources = []any{t.configData}
+	} else if t.configFile != "" {
+		sources = []any{t.configFile}
 	} else {
-		sources = []any{nodeConfigFile}
+		sources = []any{}
 	}
 
-	if config, err := xconfig.NewObject(nodeConfigFile, sources...); err != nil {
+	if config, err := xconfig.NewObject(t.configFile, sources...); err != nil {
 		return err
 	} else {
 		t.config = config
 		t.config.Referrer = t
 	}
-	clusterConfigFile := t.ClusterConfigFile()
-	sources = append([]any{clusterConfigFile}, sources...)
-	if config, err := xconfig.NewObject(clusterConfigFile, sources...); err != nil {
+	if t.clusterConfigFile != "" {
+		sources = append([]any{t.clusterConfigFile}, sources...)
+	}
+	if config, err := xconfig.NewObject(t.clusterConfigFile, sources...); err != nil {
 		return err
 	} else {
 		t.mergedConfig = config

--- a/core/omcmd/node_doc.go
+++ b/core/omcmd/node_doc.go
@@ -19,7 +19,11 @@ func (t *CmdNodeDoc) Run() error {
 		nodeaction.WithFormat(t.Output),
 		nodeaction.WithColor(t.Color),
 		nodeaction.WithLocalFunc(func() (interface{}, error) {
-			n, err := object.NewNode()
+			n, err := object.NewNode(
+				object.WithVolatile(true),
+				object.WithConfigFile(""),
+				object.WithClusterConfigFile(""),
+			)
 			if err != nil {
 				return nil, err
 			}

--- a/core/omcmd/object_doc.go
+++ b/core/omcmd/object_doc.go
@@ -28,7 +28,7 @@ func (t *CmdObjectDoc) Run(selector, kind string) error {
 			objectaction.WithOutput(t.Output),
 			objectaction.WithObjectSelector(mergedSelector),
 			objectaction.WithLocalFunc(func(ctx context.Context, p naming.Path) (interface{}, error) {
-				o, err := object.New(p)
+				o, err := object.New(p, object.WithConfigFile(""))
 				if err != nil {
 					return nil, err
 				}
@@ -56,7 +56,7 @@ func (t *CmdObjectDoc) Run(selector, kind string) error {
 	case "cfg":
 		c, err = object.NewCfg(naming.Path{})
 	case "ccfg":
-		c, err = object.NewCluster()
+		c, err = object.NewCluster(object.WithConfigFile(""))
 	default:
 		return fmt.Errorf("unknown kind %s", kind)
 	}


### PR DESCRIPTION
* Allow empty string arg in the object.New* WithConfigFile("") funcopt.O which resets the default value allocated, like /etc/opensvc/cluster.conf or /etc/opensvc/node.conf

* If the (*core).configFile or (*Node).configFile is an empty string, don't ask ini to load it, so there will not be a permission denied error when run rootless.

* Adopt the same logic for (*Node).clusterConfigFile