### PR TITLE
Add daemon self-PID check during startup and sync to disk created ssh key

### DIFF
--- a/daemon/daemonapi/get_node_ssh_key.go
+++ b/daemon/daemonapi/get_node_ssh_key.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opensvc/om3/core/client"
 	"github.com/opensvc/om3/core/node"
 	"github.com/opensvc/om3/util/command"
+	"github.com/opensvc/om3/util/file"
 )
 
 func (a *DaemonAPI) GetNodeSSHKey(ctx echo.Context, nodename string) error {
@@ -59,8 +60,18 @@ func (a *DaemonAPI) getLocalSSHKey(ctx echo.Context) error {
 			return err
 		}
 		data, err = os.ReadFile(pubFile)
-	}
-	if err != nil {
+		if err != nil {
+			log.Warnf("%s", err)
+			return err
+		}
+		for _, name := range []string{keyFile, pubFile} {
+			// sync file to prevent unrecoverable empty file on crash
+			if err := file.Sync(name); err != nil {
+				log.Warnf("%s", err)
+				return err
+			}
+		}
+	} else if err != nil {
 		log.Warnf("%s", err)
 		return err
 	}

--- a/daemon/daemoncmd/main.go
+++ b/daemon/daemoncmd/main.go
@@ -552,6 +552,11 @@ func (t *T) isNotRunning(pid int) (bool, error) {
 	return false, nil
 }
 
+// isRunning checks if daemon is running:
+//
+//		It is running when api ping succeeds
+//	 or if process id from daemon pid file exists, matching 'daemon run' and is
+//	    not self pid.
 func (t *T) isRunning() (bool, error) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
@@ -573,6 +578,11 @@ func (t *T) isRunning() (bool, error) {
 		return false, nil
 	}
 
+	if os.Getpid() == pid {
+		// avoids false positives caused by remnants of a previous daemon PID
+		// after a fast OS reboot.
+		return false, nil
+	}
 	isNotRunning, err := t.isNotRunning(pid)
 	if err != nil {
 		return false, err

--- a/util/file/main.go
+++ b/util/file/main.go
@@ -270,3 +270,14 @@ func IsDevice(p string) (bool, error) {
 	}
 	return true, nil
 }
+
+// Sync attempts to synchronize a file's in-memory state to the storage device.
+// This ensures that the file data is safely written to disk.
+func Sync(p string) error {
+	f, err := os.Open(p)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return f.Sync()
+}


### PR DESCRIPTION
### Description  

This pull request introduces several critical updates to improve reliability and data integrity:  

- **Add self-PID check to `isRunning` function**: The daemon’s `isRunning` function is updated to ignore its own PID to prevent false positives after an OS reboot.  
- **Synchronize SSH key files**: Ensures file synchronization post-creation of SSH keys to protect against data loss caused by unexpected crashes, safeguarding private and public key files.  
- **Add `Sync` function for file operations**: Implements a utility function to flush file data from memory to disk, improving integrity for file writes on the system.  
