### PR TITLE
Simplify context check and unify OCI driver handling

### DIFF
--- a/core/driverdb/drivers_linux.go
+++ b/core/driverdb/drivers_linux.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/opensvc/om3/drivers/rescontainerkvm"
 	_ "github.com/opensvc/om3/drivers/rescontainerlxc"
 	_ "github.com/opensvc/om3/drivers/rescontainerpodman"
+	_ "github.com/opensvc/om3/drivers/rescontaineroci"
 	_ "github.com/opensvc/om3/drivers/rescontainervbox"
 	_ "github.com/opensvc/om3/drivers/resdiskcrypt"
 	_ "github.com/opensvc/om3/drivers/resdiskdrbd"

--- a/core/driverdb/drivers_linux.go
+++ b/core/driverdb/drivers_linux.go
@@ -24,4 +24,5 @@ import (
 	_ "github.com/opensvc/om3/drivers/resipnetns"
 	_ "github.com/opensvc/om3/drivers/restaskdocker"
 	_ "github.com/opensvc/om3/drivers/restaskpodman"
+	_ "github.com/opensvc/om3/drivers/restaskoci"
 )

--- a/daemon/dns/uds.go
+++ b/daemon/dns/uds.go
@@ -357,12 +357,6 @@ func (t *Manager) startUDSListener() error {
 
 		var i uint64
 		for {
-			select {
-			case <-t.ctx.Done():
-				t.log.Debugf("stop accepting (abort)")
-				_ = l.Close()
-				return
-			}
 			conn, err := l.Accept()
 			if err != nil {
 				if errors.Is(err, net.ErrClosed) {

--- a/drivers/rescontainerdocker/caps.go
+++ b/drivers/rescontainerdocker/caps.go
@@ -1,6 +1,7 @@
 package rescontainerdocker
 
 import (
+	"bytes"
 	"os/exec"
 
 	"github.com/opensvc/om3/util/capabilities"
@@ -10,15 +11,24 @@ func init() {
 	capabilities.Register(capabilitiesScanner)
 }
 
+func IsGenuine() bool {
+	b, err := exec.Command("docker", "--version").Output()
+	if err != nil {
+		return false
+	} else if bytes.Contains(b, []byte("Docker")) {
+		return true
+	}
+	return false
+}
+
 func capabilitiesScanner() ([]string, error) {
 	l := make([]string, 0)
-	drvCap := drvID.Cap()
-	if _, err := exec.LookPath("docker"); err != nil {
+	drvCap := DrvID.Cap()
+	if !IsGenuine() {
 		return l, nil
 	}
 	l = append(l, drvCap)
 	l = append(l, drvCap+".registry_creds")
 	l = append(l, drvCap+".signal")
-	l = append(l, altDrvID.Cap())
 	return l, nil
 }

--- a/drivers/rescontainerdocker/manifest.go
+++ b/drivers/rescontainerdocker/manifest.go
@@ -14,18 +14,16 @@ var (
 )
 
 var (
-	drvID    = driver.NewID(driver.GroupContainer, "docker")
-	altDrvID = driver.NewID(driver.GroupContainer, "oci")
+	DrvID = driver.NewID(driver.GroupContainer, "docker")
 )
 
 func init() {
-	driver.Register(drvID, New)
-	driver.Register(altDrvID, New)
+	driver.Register(DrvID, New)
 }
 
 // Manifest exposes to the core the input expected by the driver.
 func (t *T) Manifest() *manifest.T {
-	m := t.BT.ManifestWithID(drvID)
+	m := t.BT.ManifestWithID(DrvID)
 	m.Add(
 		keywords.Keyword{
 			Option:   "userns",

--- a/drivers/rescontaineroci/caps.go
+++ b/drivers/rescontaineroci/caps.go
@@ -1,0 +1,21 @@
+package rescontaineroci
+
+import (
+	"github.com/opensvc/om3/drivers/rescontainerdocker"
+	"github.com/opensvc/om3/drivers/rescontainerpodman"
+	"github.com/opensvc/om3/util/capabilities"
+)
+
+func init() {
+	capabilities.Register(capabilitiesScanner)
+}
+
+func capabilitiesScanner() ([]string, error) {
+	l := make([]string, 0)
+	if rescontainerdocker.IsGenuine() {
+		l = append(l, drvID.Cap())
+	} else if rescontainerpodman.IsGenuine() {
+		l = append(l, drvID.Cap())
+	}
+	return l, nil
+}

--- a/drivers/rescontaineroci/main.go
+++ b/drivers/rescontaineroci/main.go
@@ -1,0 +1,24 @@
+package rescontaineroci
+
+import (
+	"github.com/opensvc/om3/core/driver"
+	"github.com/opensvc/om3/core/resource"
+	"github.com/opensvc/om3/drivers/rescontainerdocker"
+	"github.com/opensvc/om3/drivers/rescontainerpodman"
+	"github.com/opensvc/om3/util/capabilities"
+)
+
+var (
+	drvID = driver.NewID(driver.GroupContainer, "oci")
+)
+
+func New() resource.Driver {
+	if capabilities.Has(rescontainerdocker.DrvID.Cap()) {
+		return rescontainerdocker.New()
+	}
+	return rescontainerpodman.New()
+}
+
+func init() {
+	driver.Register(drvID, New)
+}

--- a/drivers/rescontainerpodman/caps.go
+++ b/drivers/rescontainerpodman/caps.go
@@ -10,17 +10,25 @@ func init() {
 	capabilities.Register(capabilitiesScanner)
 }
 
+func IsGenuine() bool {
+	if _, err := exec.LookPath("podman"); err != nil {
+		return false
+	}
+	return true
+}
+
+// capabilitiesScanner scans and returns a list of available driver capabilities
+// as strings, depending on system tools.
+// It conditionally adds capabilities based on the availability of Podman,
+// Docker, or Docker-native systems.
 func capabilitiesScanner() ([]string, error) {
 	l := make([]string, 0)
-	drvCap := drvID.Cap()
-	if _, err := exec.LookPath("podman"); err != nil {
+	drvCap := DrvID.Cap()
+	if !IsGenuine() {
 		return l, nil
 	}
 	l = append(l, drvCap)
 	l = append(l, drvCap+".registry_creds")
 	l = append(l, drvCap+".signal")
-	if _, err := exec.LookPath("docker"); err != nil {
-		l = append(l, altDrvID.Cap())
-	}
 	return l, nil
 }

--- a/drivers/rescontainerpodman/manifest.go
+++ b/drivers/rescontainerpodman/manifest.go
@@ -2,7 +2,6 @@ package rescontainerpodman
 
 import (
 	"embed"
-	"os/exec"
 
 	"github.com/opensvc/om3/core/driver"
 	"github.com/opensvc/om3/core/keywords"
@@ -15,20 +14,16 @@ var (
 )
 
 var (
-	drvID    = driver.NewID(driver.GroupContainer, "podman")
-	altDrvID = driver.NewID(driver.GroupContainer, "oci")
+	DrvID = driver.NewID(driver.GroupContainer, "podman")
 )
 
 func init() {
-	driver.Register(drvID, New)
-	if _, err := exec.LookPath("docker"); err != nil {
-		driver.Register(altDrvID, New)
-	}
+	driver.Register(DrvID, New)
 }
 
 // Manifest exposes to the core the input expected by the driver.
 func (t *T) Manifest() *manifest.T {
-	m := t.BT.ManifestWithID(drvID)
+	m := t.BT.ManifestWithID(DrvID)
 	m.Add(
 		manifest.ContextCNIConfig,
 		keywords.Keyword{

--- a/drivers/restaskdocker/caps.go
+++ b/drivers/restaskdocker/caps.go
@@ -1,8 +1,7 @@
 package restaskdocker
 
 import (
-	"os/exec"
-
+	"github.com/opensvc/om3/drivers/rescontainerdocker"
 	"github.com/opensvc/om3/util/capabilities"
 )
 
@@ -12,11 +11,10 @@ func init() {
 
 func capabilitiesScanner() ([]string, error) {
 	l := make([]string, 0)
-	drvCap := drvID.Cap()
-	if _, err := exec.LookPath("docker"); err != nil {
+	drvCap := DrvID.Cap()
+	if !rescontainerdocker.IsGenuine() {
 		return l, nil
 	}
 	l = append(l, drvCap)
-	l = append(l, altDrvID.Cap())
 	return l, nil
 }

--- a/drivers/restaskdocker/caps.go
+++ b/drivers/restaskdocker/caps.go
@@ -1,4 +1,4 @@
-package restaskpodman
+package restaskdocker
 
 import (
 	"os/exec"

--- a/drivers/restaskdocker/main.go
+++ b/drivers/restaskdocker/main.go
@@ -1,4 +1,4 @@
-package restaskpodman
+package restaskdocker
 
 // TODO
 // * snooze

--- a/drivers/restaskdocker/manifest.go
+++ b/drivers/restaskdocker/manifest.go
@@ -1,4 +1,4 @@
-package restaskpodman
+package restaskdocker
 
 import (
 	"embed"

--- a/drivers/restaskdocker/manifest.go
+++ b/drivers/restaskdocker/manifest.go
@@ -18,18 +18,16 @@ var (
 )
 
 var (
-	drvID    = driver.NewID(driver.GroupTask, "docker")
-	altDrvID = driver.NewID(driver.GroupTask, "oci")
+	DrvID = driver.NewID(driver.GroupTask, "docker")
 )
 
 func init() {
-	driver.Register(drvID, New)
-	driver.Register(altDrvID, New)
+	driver.Register(DrvID, New)
 }
 
 // Manifest ...
 func (t *T) Manifest() *manifest.T {
-	m := manifest.New(drvID, t)
+	m := manifest.New(DrvID, t)
 	m.Kinds.Or(naming.KindSvc, naming.KindVol)
 	m.Add(
 		manifest.ContextObjectPath,

--- a/drivers/restaskoci/caps.go
+++ b/drivers/restaskoci/caps.go
@@ -1,6 +1,7 @@
-package restaskpodman
+package rescontaineroci
 
 import (
+	"github.com/opensvc/om3/drivers/rescontainerdocker"
 	"github.com/opensvc/om3/drivers/rescontainerpodman"
 	"github.com/opensvc/om3/util/capabilities"
 )
@@ -11,10 +12,10 @@ func init() {
 
 func capabilitiesScanner() ([]string, error) {
 	l := make([]string, 0)
-	drvCap := DrvID.Cap()
-	if !rescontainerpodman.IsGenuine() {
-		return l, nil
+	if rescontainerdocker.IsGenuine() {
+		l = append(l, drvID.Cap())
+	} else if rescontainerpodman.IsGenuine() {
+		l = append(l, drvID.Cap())
 	}
-	l = append(l, drvCap)
 	return l, nil
 }

--- a/drivers/restaskoci/main.go
+++ b/drivers/restaskoci/main.go
@@ -1,0 +1,24 @@
+package rescontaineroci
+
+import (
+	"github.com/opensvc/om3/core/driver"
+	"github.com/opensvc/om3/core/resource"
+	"github.com/opensvc/om3/drivers/restaskdocker"
+	"github.com/opensvc/om3/drivers/restaskpodman"
+	"github.com/opensvc/om3/util/capabilities"
+)
+
+var (
+	drvID = driver.NewID(driver.GroupTask, "oci")
+)
+
+func New() resource.Driver {
+	if capabilities.Has(restaskdocker.DrvID.Cap()) {
+		return restaskdocker.New()
+	}
+	return restaskpodman.New()
+}
+
+func init() {
+	driver.Register(drvID, New)
+}

--- a/drivers/restaskpodman/manifest.go
+++ b/drivers/restaskpodman/manifest.go
@@ -2,7 +2,6 @@ package restaskpodman
 
 import (
 	"embed"
-	"os/exec"
 
 	"github.com/opensvc/om3/core/driver"
 	"github.com/opensvc/om3/core/keywords"
@@ -19,20 +18,16 @@ var (
 )
 
 var (
-	drvID    = driver.NewID(driver.GroupTask, "podman")
-	altDrvID = driver.NewID(driver.GroupTask, "oci")
+	DrvID = driver.NewID(driver.GroupTask, "podman")
 )
 
 func init() {
-	driver.Register(drvID, New)
-	if _, err := exec.LookPath("docker"); err != nil {
-		driver.Register(altDrvID, New)
-	}
+	driver.Register(DrvID, New)
 }
 
 // Manifest ...
 func (t *T) Manifest() *manifest.T {
-	m := manifest.New(drvID, t)
+	m := manifest.New(DrvID, t)
 	m.Kinds.Or(naming.KindSvc, naming.KindVol)
 	m.Add(
 		manifest.ContextObjectPath,


### PR DESCRIPTION
### Description

This pull request includes the following changes:
- Removed redundant context check in the DNS UDS accept loop for improved readability and reduced complexity.
- Introduced an OCI task driver for dynamic container management using Docker or Podman based on system capabilities.
- Refactored driver ID handling for Docker and Podman to simplify registration and capability checks.
- Renamed invalid package name for `drivers/restaskdocker` to resolve naming issues.
- Enhanced Docker and Podman drivers to streamline integration with the unified OCI driver, improving maintainability and clarity of responsibility. 
