### PR TITLE
Remove the stop timeout context from the containerocibase driver

### DIFF
--- a/drivers/rescontainerocibase/main.go
+++ b/drivers/rescontainerocibase/main.go
@@ -565,14 +565,6 @@ func (t *BT) Stop(ctx context.Context) error {
 	}
 
 	if inspect.Running() {
-		if t.StopTimeout != nil && *t.StopTimeout > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, *t.StopTimeout)
-			defer cancel()
-			log.Debugf("stopping with timeout %s", *t.StopTimeout)
-		} else {
-			log.Debugf("stopping")
-		}
 		defer func() {
 			_, _ = t.executer.InspectRefresh(ctx)
 		}()


### PR DESCRIPTION
We set the --time <stop_timeout> on the docker stop command, so no need to add a wrapping context that would expire at the same timeout the command returns, leaving us no time to wrap-up (docker inspect is the first post-stop command executed, and is killed by context).