### PR TITLE
Fix undue "placement non-optimal" issue with standby instances

### DIFF
--- a/daemon/omon/main.go
+++ b/daemon/omon/main.go
@@ -406,7 +406,7 @@ func (t *Manager) updateStatus() {
 				t.status.PlacementState = placement.NonOptimal
 				break
 			}
-			if !instMonitor.IsHALeader && !instStatus.Avail.Is(status.Down, status.NotApplicable) {
+			if !instMonitor.IsHALeader && !instStatus.Avail.Is(status.Down, status.StandbyUp, status.StandbyDown, status.NotApplicable) {
 				t.status.PlacementState = placement.NonOptimal
 				break
 			}


### PR DESCRIPTION
Missing the StandyDown, StandyUp states detection in the omon algo that decides if place is non-optimal.