### PR TITLE
Fix the routed bridge networks segmentation algo

### DIFF
--- a/drivers/networkroutedbridge/main.go
+++ b/drivers/networkroutedbridge/main.go
@@ -168,7 +168,7 @@ func (t T) allocateSubnets() error {
 	kops := make([]keyop.T, 0)
 	for _, nodename := range nodes {
 		subnet := fmt.Sprintf("%s/%d", addr, bits-subnetOnes)
-		for i := 0; i < maxIPsPerNodes; i++ {
+		for i := 0; i < ipsPerNode; i++ {
 			addr = addr.Next()
 		}
 		kops = append(kops, keyop.T{


### PR DESCRIPTION
This segmentation is wrong, as it leaves holes between segments:

	subnet@dev2n1 = 10.123.0.0/20
	subnet@dev2n2 = 10.123.64.0/20
	subnet@dev2n3 = 10.123.128.0/20

Fix the algo to allocate contiguous segments:

	subnet@dev2n1 = 10.123.0.0/20
	subnet@dev2n2 = 10.123.16.0/20
	subnet@dev2n3 = 10.123.32.0/20