### PR TITLE
Fix UUID key formatting in `resdiskmd`  

### DIFF
--- a/drivers/resdiskmd/main.go
+++ b/drivers/resdiskmd/main.go
@@ -200,8 +200,8 @@ func (t *T) uuidKey() key.T {
 		Section: t.RID(),
 		Option:  "uuid",
 	}
-	if t.Shared {
-		k.Section = k.Section + "@" + hostname.Hostname()
+	if !t.Shared {
+		k.Option = k.Option + "@" + hostname.Hostname()
 	}
 	return k
 }


### PR DESCRIPTION
### Description of Changes  
- Corrected unexpected section key for UUID from `disk#<rid>@<nodename>` to `disk#<rid>.uuid@<nodename>`.  
- Ensures proper provisioned UUID format in `resdiskmd`.  
