### PR TITLE
Allow the resources type keyword to be a reference

### DIFF
--- a/core/object/actor.go
+++ b/core/object/actor.go
@@ -264,15 +264,15 @@ func (t *actor) ConfigureResources() {
 		}
 		driverGroup := rid.DriverGroup()
 		if driverGroup == driver.GroupUnknown {
-			t.log.Attr("rid", k).Attr("f", "listResources").Debugf("unknown driver group in rid %s", k)
+			t.log.Attr("rid", k).Debugf("unknown driver group in rid %s", k)
 			continue
 		}
 		typeKey := key.New(k, "type")
-		driverName := t.config.Get(typeKey)
+		driverName := t.config.GetString(typeKey)
 		driverID := driver.NewID(driverGroup, driverName)
 		factory := resource.NewResourceFunc(driverID)
 		if factory == nil {
-			t.log.Attr("driver", driverID.String()).Debugf("unknown driver %s", driverID)
+			t.log.Debugf("unknown driver %s", driverID)
 			continue
 		}
 		r := factory()

--- a/core/object/config_test.go
+++ b/core/object/config_test.go
@@ -144,3 +144,22 @@ l = a b
 	require.NoError(t, err)
 	require.Equal(t, []string{"b", "a"}, value)
 }
+
+func TestConfigDerefResourceType(t *testing.T) {
+	cf := []byte(`
+[fs#1]
+type = {env.fstype}
+
+[env]
+fstype = flag
+`)
+
+	p, _ := naming.ParsePath("test/svc/svc1")
+	o, err := NewSvc(p, WithConfigData(cf))
+	require.NoError(t, err)
+
+	_, err = SetClusterConfig()
+	o.ConfigureResources()
+	r := o.ResourceByID("fs#1")
+	require.NotNil(t, r)
+}


### PR DESCRIPTION
The 2.1 version allowed that. Ensure backward compatibility.

Add a test to avoid regression.