### PR TITLE
Implement the ip.host interface alias mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,9 +290,11 @@
     * `dns_update`
    
 * **Removed feature:**
-    The interface aliasing mode is dropped from the `ip.host` driver.
-    The `alias=true` keyword is now ignored, and the ip stacking mode is always selected.
-    Users must migrate to `alias=false` before upgrading to om3.
+    The interface macvtap mode is dropped from the `ip.host` driver (ie the `dev=eth0@foo` syntax).
+
+* **Changed default:**
+    The `alias` keyword default value is now `true`, activating the ip stacking behaviour.
+    Setting `dev=eth0:0` still forces the address labelling mode.
 
 * **Collector DNS zone:**
     This feature of the collector, used by the ip driver for one of its provisioning methods, is deprecated.

--- a/core/om/factory.go
+++ b/core/om/factory.go
@@ -1441,6 +1441,7 @@ func newCmdNodeConfigShow() *cobra.Command {
 	addFlagsGlobal(flags, &options.OptsGlobal)
 	commoncmd.FlagEval(flags, &options.Eval)
 	commoncmd.FlagImpersonate(flags, &options.Impersonate)
+	commoncmd.FlagSections(flags, &options.Sections)
 	return cmd
 }
 
@@ -2646,6 +2647,7 @@ func newCmdObjectConfigShow(kind string) *cobra.Command {
 	addFlagsGlobal(flags, &options.OptsGlobal)
 	commoncmd.FlagEval(flags, &options.Eval)
 	commoncmd.FlagImpersonate(flags, &options.Impersonate)
+	commoncmd.FlagSections(flags, &options.Sections)
 	return cmd
 }
 

--- a/core/omcmd/node_config_show.go
+++ b/core/omcmd/node_config_show.go
@@ -3,6 +3,7 @@ package omcmd
 import (
 	"github.com/opensvc/om3/core/nodeaction"
 	"github.com/opensvc/om3/core/object"
+	"github.com/opensvc/om3/core/rawconfig"
 )
 
 type (
@@ -11,6 +12,7 @@ type (
 		Eval         bool
 		Impersonate  string
 		NodeSelector string
+		Sections     []string
 	}
 )
 
@@ -25,12 +27,17 @@ func (t *CmdNodeConfigShow) Run() error {
 			if err != nil {
 				return nil, err
 			}
+			data := rawconfig.New()
 			switch {
 			case t.Eval:
-				return n.EvalConfigAs(t.Impersonate)
+				data, err = n.EvalConfigAs(t.Impersonate)
 			default:
-				return n.RawConfig()
+				data, err = n.RawConfig()
 			}
+			if err != nil {
+				return nil, err
+			}
+			return data.Filter(t.Sections), nil
 		}),
 	).Do()
 }

--- a/core/omcmd/object_config_show.go
+++ b/core/omcmd/object_config_show.go
@@ -22,6 +22,7 @@ type (
 		OptsGlobal
 		Eval        bool
 		Impersonate string
+		Sections    []string
 	}
 )
 
@@ -44,7 +45,7 @@ func (t *CmdObjectConfigShow) extract(selector string) (result, error) {
 		if d, err := t.extractOne(p, c); err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", p, err)
 		} else {
-			data[p.String()] = d
+			data[p.String()] = d.Filter(t.Sections)
 		}
 	}
 	return data, nil

--- a/core/ox/factory.go
+++ b/core/ox/factory.go
@@ -1418,6 +1418,7 @@ func newCmdNodeConfigShow() *cobra.Command {
 	addFlagsGlobal(flags, &options.OptsGlobal)
 	commoncmd.FlagEval(flags, &options.Eval)
 	commoncmd.FlagImpersonate(flags, &options.Impersonate)
+	commoncmd.FlagSections(flags, &options.Sections)
 	return cmd
 }
 
@@ -2061,6 +2062,7 @@ func newCmdObjectConfigShow(kind string) *cobra.Command {
 	addFlagsGlobal(flags, &options.OptsGlobal)
 	commoncmd.FlagEval(flags, &options.Eval)
 	commoncmd.FlagImpersonate(flags, &options.Impersonate)
+	commoncmd.FlagSections(flags, &options.Sections)
 	return cmd
 }
 

--- a/core/oxcmd/node_config_show.go
+++ b/core/oxcmd/node_config_show.go
@@ -22,6 +22,7 @@ type (
 		Eval         bool
 		Impersonate  string
 		NodeSelector string
+		Sections     []string
 	}
 )
 
@@ -117,7 +118,7 @@ func (t *CmdNodeConfigShow) extract(nodenames []string, c *client.T) (result, er
 				errC <- err
 				return
 			} else {
-				data[nodename] = d
+				data[nodename] = d.Filter(t.Sections)
 			}
 		}(nodename)
 	}

--- a/core/oxcmd/object_config_show.go
+++ b/core/oxcmd/object_config_show.go
@@ -21,6 +21,7 @@ type (
 		OptsGlobal
 		Eval        bool
 		Impersonate string
+		Sections    []string
 	}
 )
 
@@ -43,7 +44,7 @@ func (t *CmdObjectConfigShow) extract(selector string) (result, error) {
 		if d, err := t.extractFromDaemon(p, c); err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", p, err)
 		} else {
-			data[p.String()] = d
+			data[p.String()] = d.Filter(t.Sections)
 		}
 	}
 	return data, nil

--- a/core/rawconfig/raw.go
+++ b/core/rawconfig/raw.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -40,6 +41,19 @@ func (t *T) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+func (t T) Filter(keys []string) T {
+	if len(keys) == 0 {
+		return t
+	}
+	ks := append([]string{}, t.Data.Keys()...)
+	for _, k := range ks {
+		if !slices.Contains(keys, k) {
+			t.Data.Delete(k)
+		}
+	}
+	return t
 }
 
 // IsZero returns true if the Raw data has not been initialized

--- a/drivers/resip/main.go
+++ b/drivers/resip/main.go
@@ -4,11 +4,48 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/opensvc/om3/util/plog"
 	"github.com/opensvc/om3/util/stringset"
+	"github.com/vishvananda/netlink"
 )
+
+func AllocateDevLabel(dev string) (string, error) {
+	link, err := netlink.LinkByName(dev)
+	if err != nil {
+		return "", fmt.Errorf("allocate dev label: could not get interface %s: %w", dev, err)
+	}
+
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		return "", fmt.Errorf("allocate dev label: could not list addresses on interface %s: %w", dev, err)
+	}
+
+	m := make(map[string]any)
+	for _, addr := range addrs {
+		label := addr.Label
+		if label != "" {
+			m[label] = nil
+		}
+	}
+
+	maxLabelIndex := 1000
+	for i := 0; i < maxLabelIndex; i += 1 {
+		label := fmt.Sprintf("%s:%d", dev, i)
+		if _, ok := m[label]; ok {
+			continue
+		}
+		return label, nil
+	}
+	return "", fmt.Errorf("allocate dev label: could not find a free label index on interface %s", dev)
+}
+
+func SplitDevLabel(s string) (string, string) {
+	before, after, _ := strings.Cut(s, ":")
+	return before, after
+}
 
 func lookupHostOnDNS(ctx context.Context, name, dns string) ([]string, error) {
 	r := &net.Resolver{

--- a/drivers/resiphost/arp.go
+++ b/drivers/resiphost/arp.go
@@ -4,6 +4,6 @@ package resiphost
 
 import "github.com/j-keck/arping"
 
-func (t *T) arpGratuitous() error {
-	return arping.GratuitousArpOverIfaceByName(t.ipaddr(), t.Dev)
+func (t *T) arpGratuitous(dev string) error {
+	return arping.GratuitousArpOverIfaceByName(t.ipaddr(), dev)
 }

--- a/drivers/resiphost/main_cmd.go
+++ b/drivers/resiphost/main_cmd.go
@@ -1,0 +1,33 @@
+package resiphost
+
+import (
+	"github.com/opensvc/om3/util/command"
+	"github.com/rs/zerolog"
+)
+
+func (t *T) addrAdd(addr, dev, label string) error {
+	args := []string{"ip", "addr", "add", addr, "dev", dev}
+	if label != "" {
+		args = append(args, "label", label)
+	}
+	return command.New(
+		command.WithName(args[0]),
+		command.WithArgs(args[1:]),
+		command.WithLogger(t.Log()),
+		command.WithCommandLogLevel(zerolog.InfoLevel),
+		command.WithStdoutLogLevel(zerolog.InfoLevel),
+		command.WithStderrLogLevel(zerolog.ErrorLevel),
+	).Run()
+}
+
+func (t *T) addrDel(addr, dev string) error {
+	args := []string{"ip", "addr", "del", addr, "dev", dev}
+	return command.New(
+		command.WithName(args[0]),
+		command.WithArgs(args[1:]),
+		command.WithLogger(t.Log()),
+		command.WithCommandLogLevel(zerolog.InfoLevel),
+		command.WithStdoutLogLevel(zerolog.InfoLevel),
+		command.WithStderrLogLevel(zerolog.ErrorLevel),
+	).Run()
+}

--- a/util/command/main.go
+++ b/util/command/main.go
@@ -288,7 +288,9 @@ func (t *T) Wait() error {
 	t.wg.Wait()
 	err := t.cmd.Wait()
 	if t.ctx.Err() == context.DeadlineExceeded {
-		t.log.Attr("cmd", t.cmd.String()).Levelf(t.logLevel, "wait exec: %s", err)
+		if t.log != nil {
+			t.log.Attr("cmd", t.cmd.String()).Levelf(t.logLevel, "wait exec: %s", err)
+		}
 		return context.DeadlineExceeded
 	}
 	if err != nil {


### PR DESCRIPTION
Use the `ip` instead of `ifconfig` that opensvc v2.1 used, as this command is deprecated.

Example: Forced label, implicit alias=false:

	[ip#label1]
	type = host
	name = 128.0.0.11
	dev = br-prd:11
	netmask = 24

Example: Dynamic label, explicit alias=false:

	[ip#label2]
	type = host
	name = 128.0.0.12
	dev = br-prd
	alias = false
	netmask = 24

Make the ip.host resource label report the label if any:

	svc1                             up
	└ instances
	  └ dev2n1                       up     idle
	    ├ resources
	    ...
	    │ ├ ip#label1      ...../..  up     host 128.0.0.11/24 br-prd label br-prd:11
	    │ ├ ip#label2      ...../..  up     host 128.0.0.12/24 br-prd label br-prd:0