### PR TITLE
Rename heartbeat-related identifiers for clarity and consistency

### DIFF
--- a/core/om/text/node-events/event-kind
+++ b/core/om/text/node-events/event-kind
@@ -19,7 +19,7 @@
    Exec, ExecFailed, ExecSuccess
 
  heartbeat:
-   HbMessageTypeUpdated, HbNodePing, HbPing, HbStale, HbStatusUpdated
+   HbMessageTypeUpdated, HbNodePing, HbPing, HbStale
 
  instance:
    InstanceConfigDeleted, InstanceConfigManagerDone, InstanceConfigUpdated

--- a/core/om/text/node-events/event-kind
+++ b/core/om/text/node-events/event-kind
@@ -19,7 +19,7 @@
    Exec, ExecFailed, ExecSuccess
 
  heartbeat:
-   HbMessageTypeUpdated, HbNodePing, HbPing, HbStale
+   HeartbeatMessageTypeUpdated, HeartbeatNodePing, HeartbeatPing, HeartbeatStale
 
  instance:
    InstanceConfigDeleted, InstanceConfigManagerDone, InstanceConfigUpdated

--- a/core/ox/text/node-events/event-kind
+++ b/core/ox/text/node-events/event-kind
@@ -19,7 +19,7 @@
    Exec, ExecFailed, ExecSuccess
 
  heartbeat:
-   HbMessageTypeUpdated, HbNodePing, HbPing, HbStale, HbStatusUpdated
+   HbMessageTypeUpdated, HbNodePing, HbPing, HbStale
 
  instance:
    InstanceConfigDeleted, InstanceConfigManagerDone, InstanceConfigUpdated

--- a/core/ox/text/node-events/event-kind
+++ b/core/ox/text/node-events/event-kind
@@ -19,7 +19,7 @@
    Exec, ExecFailed, ExecSuccess
 
  heartbeat:
-   HbMessageTypeUpdated, HbNodePing, HbPing, HbStale
+   HeartbeatMessageTypeUpdated, HeartbeatNodePing, HeartbeatPing, HeartbeatStale
 
  instance:
    InstanceConfigDeleted, InstanceConfigManagerDone, InstanceConfigUpdated

--- a/daemon/daemondata/daemon_hb.go
+++ b/daemon/daemondata/daemon_hb.go
@@ -50,7 +50,7 @@ func (d *data) setHbMsgPatchLength(node string, length int) {
 }
 
 // setHbMsgType update the sub.hb.mode.x.Type for node,
-// if value is changed publish msgbus.HbMessageTypeUpdated
+// if value is changed publish msgbus.HeartbeatMessageTypeUpdated
 func (d *data) setHbMsgType(node string, msgType string) {
 	previous := d.hbMsgType[node]
 	if msgType != previous {
@@ -61,7 +61,7 @@ func (d *data) setHbMsgType(node string, msgType string) {
 				joinedNodes = append(joinedNodes, n)
 			}
 		}
-		d.publisher.Pub(&msgbus.HbMessageTypeUpdated{
+		d.publisher.Pub(&msgbus.HeartbeatMessageTypeUpdated{
 			Node:          node,
 			From:          previous,
 			To:            msgType,

--- a/daemon/discover/cfg.go
+++ b/daemon/discover/cfg.go
@@ -36,7 +36,7 @@ func (t *Manager) startSubscriptions() *pubsub.Subscription {
 	sub.AddFilter(&msgbus.ClusterConfigUpdated{})
 	sub.AddFilter(&msgbus.ConfigFileUpdated{})
 
-	sub.AddFilter(&msgbus.HbMessageTypeUpdated{}, t.labelLocalhost)
+	sub.AddFilter(&msgbus.HeartbeatMessageTypeUpdated{}, t.labelLocalhost)
 
 	sub.AddFilter(&msgbus.InstanceConfigDeleting{}, t.labelLocalhost)
 	sub.AddFilter(&msgbus.InstanceConfigFor{})
@@ -93,8 +93,8 @@ func (t *Manager) cfg(started chan<- bool) {
 			case *msgbus.ConfigFileUpdated:
 				t.onConfigFileUpdated(c)
 
-			case *msgbus.HbMessageTypeUpdated:
-				t.onHbMessageTypeUpdated(c)
+			case *msgbus.HeartbeatMessageTypeUpdated:
+				t.onHeartbeatMessageTypeUpdated(c)
 
 			case *msgbus.InstanceConfigDeleting:
 				t.onInstanceConfigDeleting(c)
@@ -468,10 +468,10 @@ func (t *Manager) removeConfigFileAndDisableRecover(p naming.Path, updatedAt tim
 	}
 }
 
-// onHbMessageTypeUpdated must re-emit pending instanceConfigFor event when the
-// HbMessageTypeUpdated.To is "patch".
+// onHeartbeatMessageTypeUpdated must re-emit pending instanceConfigFor event when the
+// HeartbeatMessageTypeUpdated.To is "patch".
 // instanceConfigFor are not applied during apply full.
-func (t *Manager) onHbMessageTypeUpdated(c *msgbus.HbMessageTypeUpdated) {
+func (t *Manager) onHeartbeatMessageTypeUpdated(c *msgbus.HeartbeatMessageTypeUpdated) {
 	if c.To != "patch" {
 		return
 	}

--- a/daemon/hb/hbctrl/main.go
+++ b/daemon/hb/hbctrl/main.go
@@ -278,10 +278,10 @@ func (c *C) run() {
 				label := pubsub.Label{"hb", "ping/stale"}
 				if o.Name == evStale {
 					c.log.Warnf("event %s for %s from %s", o.Name, o.Nodename, o.HbID)
-					pub.Pub(&msgbus.HbStale{Nodename: o.Nodename, HbID: o.HbID, Time: time.Now()}, label)
+					pub.Pub(&msgbus.HeartbeatStale{Nodename: o.Nodename, HbID: o.HbID, Time: time.Now()}, label)
 				} else {
 					c.log.Infof("event %s for %s from %s", o.Name, o.Nodename, o.HbID)
-					pub.Pub(&msgbus.HbPing{Nodename: o.Nodename, HbID: o.HbID, Time: time.Now()}, label)
+					pub.Pub(&msgbus.HeartbeatPing{Nodename: o.Nodename, HbID: o.HbID, Time: time.Now()}, label)
 				}
 				if remote, ok := remotes[o.Nodename]; ok {
 					if strings.HasSuffix(o.HbID, ".rx") {
@@ -289,7 +289,7 @@ func (c *C) run() {
 						case evBeating:
 							if remote.rxBeating == 0 {
 								c.log.Infof("beating node %s", o.Nodename)
-								pub.Pub(&msgbus.HbNodePing{Node: o.Nodename, IsAlive: true}, pubsub.Label{"node", o.Nodename})
+								pub.Pub(&msgbus.HeartbeatNodePing{Node: o.Nodename, IsAlive: true}, pubsub.Label{"node", o.Nodename})
 							}
 							remote.rxBeating++
 						case evStale:
@@ -300,7 +300,7 @@ func (c *C) run() {
 						}
 						if remote.rxBeating == 0 {
 							c.log.Infof("stale node %s", o.Nodename)
-							pub.Pub(&msgbus.HbNodePing{Node: o.Nodename, IsAlive: false}, pubsub.Label{"node", o.Nodename})
+							pub.Pub(&msgbus.HeartbeatNodePing{Node: o.Nodename, IsAlive: false}, pubsub.Label{"node", o.Nodename})
 						}
 						remotes[o.Nodename] = remote
 					}

--- a/daemon/hb/hbctrl/main_test.go
+++ b/daemon/hb/hbctrl/main_test.go
@@ -43,7 +43,7 @@ func setupCtrl(ctx context.Context) *C {
 	return c
 }
 
-func TestCmdSetPeerSuccessCreatesPublishHbNodePing(t *testing.T) {
+func TestCmdSetPeerSuccessCreatesPublishHeartbeatNodePing(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = bootstrapDaemon(ctx, t)
@@ -64,7 +64,7 @@ func TestCmdSetPeerSuccessCreatesPublishHbNodePing(t *testing.T) {
 			node             string
 			events           []event
 			readPingDuration time.Duration
-			expected         []msgbus.HbNodePing
+			expected         []msgbus.HeartbeatNodePing
 		}
 	)
 	cases := map[string]testCase{
@@ -77,7 +77,7 @@ func TestCmdSetPeerSuccessCreatesPublishHbNodePing(t *testing.T) {
 				{ping: true, hb: "hb#0.rx", node: "node5", delay: 1 * time.Millisecond},
 			},
 			readPingDuration: 200 * time.Millisecond,
-			expected: []msgbus.HbNodePing{
+			expected: []msgbus.HeartbeatNodePing{
 				{Msg: pubsub.Msg{Labels: pubsub.NewLabels("node", "node5")}, Node: "node5", IsAlive: true},
 			},
 		},
@@ -93,7 +93,7 @@ func TestCmdSetPeerSuccessCreatesPublishHbNodePing(t *testing.T) {
 				{ping: true, hb: "hb#1.rx", node: "node6", delay: 13 * time.Millisecond},
 			},
 			readPingDuration: 200 * time.Millisecond,
-			expected: []msgbus.HbNodePing{
+			expected: []msgbus.HeartbeatNodePing{
 				{Msg: pubsub.Msg{Labels: pubsub.NewLabels("node", "node6")}, Node: "node6", IsAlive: true},
 				{Msg: pubsub.Msg{Labels: pubsub.NewLabels("node", "node6")}, Node: "node6", IsAlive: false},
 				{Msg: pubsub.Msg{Labels: pubsub.NewLabels("node", "node6")}, Node: "node6", IsAlive: true},
@@ -130,7 +130,7 @@ func TestCmdSetPeerSuccessCreatesPublishHbNodePing(t *testing.T) {
 				{delay: 3 * time.Millisecond, node: "node7", hb: "hb#2.rx", ping: true},
 			},
 			readPingDuration: 200 * time.Millisecond,
-			expected: []msgbus.HbNodePing{
+			expected: []msgbus.HeartbeatNodePing{
 				{Msg: pubsub.Msg{Labels: pubsub.NewLabels("node", "node7")}, Node: "node7", IsAlive: true},
 			},
 		},
@@ -146,7 +146,7 @@ func TestCmdSetPeerSuccessCreatesPublishHbNodePing(t *testing.T) {
 				{delay: 13 * time.Millisecond, node: "node8", hb: "hb#5.rx", ping: false},
 			},
 			readPingDuration: 200 * time.Millisecond,
-			expected: []msgbus.HbNodePing{
+			expected: []msgbus.HeartbeatNodePing{
 				{Msg: pubsub.Msg{Labels: pubsub.NewLabels("node", "node8")}, Node: "node8", IsAlive: true},
 				{Msg: pubsub.Msg{Labels: pubsub.NewLabels("node", "node8")}, Node: "node8", IsAlive: false},
 			},
@@ -168,7 +168,7 @@ func TestCmdSetPeerSuccessCreatesPublishHbNodePing(t *testing.T) {
 				{delay: 13 * time.Millisecond, node: "node9", hb: "hb#6.rx", ping: false},
 			},
 			readPingDuration: 500 * time.Millisecond,
-			expected: []msgbus.HbNodePing{
+			expected: []msgbus.HeartbeatNodePing{
 				{Msg: pubsub.Msg{Labels: pubsub.NewLabels("node", "node9")}, Node: "node9", IsAlive: true},
 				{Msg: pubsub.Msg{Labels: pubsub.NewLabels("node", "node9")}, Node: "node9", IsAlive: false},
 				{Msg: pubsub.Msg{Labels: pubsub.NewLabels("node", "node9")}, Node: "node9", IsAlive: true},
@@ -185,25 +185,25 @@ func TestCmdSetPeerSuccessCreatesPublishHbNodePing(t *testing.T) {
 			tNode := tc.node
 
 			sub := pubsub.SubFromContext(ctx, name, pubsub.Timeout(time.Second))
-			sub.AddFilter(&msgbus.HbNodePing{}, pubsub.Label{"node", tNode})
+			sub.AddFilter(&msgbus.HeartbeatNodePing{}, pubsub.Label{"node", tNode})
 			sub.Start()
 			defer func() {
 				_ = sub.Stop()
 			}()
 
-			pingMsgC := make(chan []msgbus.HbNodePing)
+			pingMsgC := make(chan []msgbus.HeartbeatNodePing)
 			go func() {
-				pingMsgs := make([]msgbus.HbNodePing, 0)
-				t.Log("read HbNodePing messages ...")
+				pingMsgs := make([]msgbus.HeartbeatNodePing, 0)
+				t.Log("read HeartbeatNodePing messages ...")
 				timeout := time.After(tc.readPingDuration)
 				for {
 					select {
 					case i := <-sub.C:
-						msg := i.(*msgbus.HbNodePing)
-						t.Logf("receive msgbus.HbNodePing notification: ---- %+v", msg)
+						msg := i.(*msgbus.HeartbeatNodePing)
+						t.Logf("receive msgbus.HeartbeatNodePing notification: ---- %+v", msg)
 						pingMsgs = append(pingMsgs, *msg)
 					case <-timeout:
-						t.Logf("timeout reached, HbNodePing messages are: %+v", pingMsgs)
+						t.Logf("timeout reached, HeartbeatNodePing messages are: %+v", pingMsgs)
 						pingMsgC <- pingMsgs
 						return
 					}
@@ -234,7 +234,7 @@ func TestCmdSetPeerSuccessCreatesPublishHbNodePing(t *testing.T) {
 
 			found := <-pingMsgC
 			require.Equalf(t, tc.expected, found,
-				"unexpected published HbNodePing from %s\n%v",
+				"unexpected published HeartbeatNodePing from %s\n%v",
 				name, tc.events)
 		})
 	}

--- a/daemon/hb/hbctrl/peer_drop.go
+++ b/daemon/hb/hbctrl/peer_drop.go
@@ -14,16 +14,16 @@ import (
 	"github.com/opensvc/om3/util/pubsub"
 )
 
-// peerDropWorker is responsible for dropping peer data on msgbus.HbNodePing{isAlive: false, Node: <peer>}.
+// peerDropWorker is responsible for dropping peer data on msgbus.HeartbeatNodePing{isAlive: false, Node: <peer>}.
 // If <peer> node is in MonitorStateMaintenance state, the drop is delayed until maintenanceGracePeriod is reached.
-// The delayed <peer> node drop is canceled on msgbus.HbNodePing{isAlive: true, Node: <peer>}.
+// The delayed <peer> node drop is canceled on msgbus.HeartbeatNodePing{isAlive: true, Node: <peer>}.
 func peerDropWorker(ctx context.Context) {
 	databus := daemondata.FromContext(ctx)
 	log := plog.NewDefaultLogger().Attr("pkg", "daemon/hbctrl:peerDropWorker").WithPrefix("daemon: hbctrl: peer drop: ")
 	sub := pubsub.SubFromContext(ctx, "daemon.hb.peer_drop_worker")
 	sub.AddFilter(&msgbus.ConfigFileUpdated{}, pubsub.Label{"path", "cluster"})
 	sub.AddFilter(&msgbus.ConfigFileUpdated{}, pubsub.Label{"path", ""})
-	sub.AddFilter(&msgbus.HbNodePing{})
+	sub.AddFilter(&msgbus.HeartbeatNodePing{})
 	sub.Start()
 	defer sub.Stop()
 
@@ -90,7 +90,7 @@ func peerDropWorker(ctx context.Context) {
 		}
 	}
 
-	onHbNodePing := func(c *msgbus.HbNodePing) {
+	onHeartbeatNodePing := func(c *msgbus.HeartbeatNodePing) {
 		peer := c.Node
 		if c.IsAlive {
 			if drop, ok := dropM[peer]; ok {
@@ -110,8 +110,8 @@ func peerDropWorker(ctx context.Context) {
 			switch c := i.(type) {
 			case *msgbus.ConfigFileUpdated:
 				onConfigFileUpdated(c)
-			case *msgbus.HbNodePing:
-				onHbNodePing(c)
+			case *msgbus.HeartbeatNodePing:
+				onHeartbeatNodePing(c)
 			}
 		}
 	}

--- a/daemon/msgbus/main_test.go
+++ b/daemon/msgbus/main_test.go
@@ -20,29 +20,29 @@ func TestSubscriptionFilter(t *testing.T) {
 	defer bus.Stop()
 
 	sub := pubsub.SubFromContext(ctx, t.Name())
-	sub.AddFilter(&HbNodePing{}, pubsub.Label{"node", "node10"})
+	sub.AddFilter(&HeartbeatNodePing{}, pubsub.Label{"node", "node10"})
 	sub.Start()
 	defer sub.Stop()
 
 	pub := pubsub.PubFromContext(ctx)
 
 	// publish non watched type
-	pub.Pub(&HbStale{}, pubsub.Label{"node", "node1"})
+	pub.Pub(&HeartbeatStale{}, pubsub.Label{"node", "node1"})
 
 	// publish message with watched type but not watched label
-	pub.Pub(&HbNodePing{
+	pub.Pub(&HeartbeatNodePing{
 		Node:    "node1",
 		IsAlive: true,
 	}, pubsub.Label{"node", "node1"})
 
 	// publish message with watched type but without label
-	pub.Pub(&HbNodePing{
+	pub.Pub(&HeartbeatNodePing{
 		Node:    "node1",
 		IsAlive: true,
 	})
 
 	// publish message with the watched type and label
-	pub.Pub(&HbNodePing{
+	pub.Pub(&HeartbeatNodePing{
 		Node:    "node10",
 		IsAlive: true,
 	}, pubsub.Label{"node", "node10"})
@@ -51,7 +51,7 @@ func TestSubscriptionFilter(t *testing.T) {
 	t.Logf("verify received message from correct label (timeout: %s)", receiveMsgTimeout)
 	select {
 	case i := <-sub.C:
-		require.Equal(t, "node10", i.(*HbNodePing).Node)
+		require.Equal(t, "node10", i.(*HeartbeatNodePing).Node)
 	case <-time.After(receiveMsgTimeout):
 		t.Fatalf("timeout, no message received")
 	}

--- a/daemon/msgbus/messages.go
+++ b/daemon/msgbus/messages.go
@@ -104,8 +104,6 @@ var (
 
 		"HbStale": func() any { return &HbStale{} },
 
-		"HbStatusUpdated": func() any { return &HbStatusUpdated{} },
-
 		"InstanceConfigDeleted": func() any { return &InstanceConfigDeleted{} },
 
 		"InstanceConfigDeleting": func() any { return &InstanceConfigDeleting{} },
@@ -441,13 +439,6 @@ type (
 		Nodename   string    `json:"node" yaml:"node"`
 		HbID       string    `json:"hb_id" yaml:"hb_id"`
 		Time       time.Time `json:"at" yaml:"at"`
-	}
-
-	HbStatusUpdated struct {
-		pubsub.Msg `yaml:",inline"`
-		Node       string `json:"node" yaml:"node"`
-
-		Value daemonsubsystem.HeartbeatStream `json:"stream" yaml:"stream"`
 	}
 
 	InstanceConfigDeleted struct {
@@ -1015,10 +1006,6 @@ func (e *HbStale) String() string {
 
 func (e *HbStale) Kind() string {
 	return "HbStale"
-}
-
-func (e *HbStatusUpdated) Kind() string {
-	return "HbStatusUpdated"
 }
 
 func (e *InstanceConfigDeleted) Kind() string {

--- a/daemon/msgbus/messages.go
+++ b/daemon/msgbus/messages.go
@@ -320,7 +320,7 @@ type (
 		pubsub.Msg `yaml:",inline"`
 		Node       string `json:"node" yaml:"node"`
 
-		Value daemonsubsystem.Heartbeat `json:"hb" yaml:"hb"`
+		Value daemonsubsystem.Heartbeat `json:"heartbeat" yaml:"heartbeat"`
 	}
 
 	DaemonListenerUpdated struct {

--- a/daemon/msgbus/messages.go
+++ b/daemon/msgbus/messages.go
@@ -96,13 +96,13 @@ var (
 		// TODO: remove when CHANGELOG.md: forget_peer (b2.1) -> ForgetPeer
 		"forget_peer": func() any { return &ForgetPeer{} },
 
-		"HbMessageTypeUpdated": func() any { return &HbMessageTypeUpdated{} },
+		"HeartbeatMessageTypeUpdated": func() any { return &HeartbeatMessageTypeUpdated{} },
 
-		"HbNodePing": func() any { return &HbNodePing{} },
+		"HeartbeatNodePing": func() any { return &HeartbeatNodePing{} },
 
-		"HbPing": func() any { return &HbPing{} },
+		"HeartbeatPing": func() any { return &HeartbeatPing{} },
 
-		"HbStale": func() any { return &HbStale{} },
+		"HeartbeatStale": func() any { return &HeartbeatStale{} },
 
 		"InstanceConfigDeleted": func() any { return &InstanceConfigDeleted{} },
 
@@ -406,21 +406,20 @@ type (
 		pubsub.Msg `yaml:",inline"`
 		Node       string `json:"node" yaml:"node"`
 	}
-
-	HbNodePing struct {
+	HeartbeatNodePing struct {
 		pubsub.Msg `yaml:",inline"`
 		Node       string `json:"node" yaml:"node"`
 		IsAlive    bool   `json:"is_alive" yaml:"is_alive"`
 	}
 
-	HbPing struct {
+	HeartbeatPing struct {
 		pubsub.Msg `yaml:",inline"`
 		Nodename   string    `json:"to" yaml:"to"`
 		HbID       string    `json:"hb_id" yaml:"hb_id"`
 		Time       time.Time `json:"at" yaml:"at"`
 	}
 
-	HbMessageTypeUpdated struct {
+	HeartbeatMessageTypeUpdated struct {
 		pubsub.Msg `yaml:",inline"`
 		Node       string   `json:"node" yaml:"node"`
 		From       string   `json:"old_type" yaml:"old_type"`
@@ -434,7 +433,7 @@ type (
 		InstalledGens node.Gen `json:"installed_gens" yaml:"installed_gens"`
 	}
 
-	HbStale struct {
+	HeartbeatStale struct {
 		pubsub.Msg `yaml:",inline"`
 		Nodename   string    `json:"node" yaml:"node"`
 		HbID       string    `json:"hb_id" yaml:"hb_id"`
@@ -976,36 +975,36 @@ func (e *ForgetPeer) Kind() string {
 	return "forget_peer"
 }
 
-func (e *HbMessageTypeUpdated) Kind() string {
-	return "HbMessageTypeUpdated"
+func (e *HeartbeatMessageTypeUpdated) Kind() string {
+	return "HeartbeatMessageTypeUpdated"
 }
 
-func (e *HbNodePing) String() string {
+func (e *HeartbeatNodePing) String() string {
 	if e.IsAlive {
-		return "HbNodePing: " + e.Node + " ok"
+		return "HeartbeatNodePing: " + e.Node + " ok"
 	} else {
-		return "HbNodePing: " + e.Node + " stale"
+		return "HeartbeatNodePing: " + e.Node + " stale"
 	}
 }
 
-func (e *HbNodePing) Kind() string {
-	return "HbNodePing"
+func (e *HeartbeatNodePing) Kind() string {
+	return "HeartbeatNodePing"
 }
 
-func (e *HbPing) String() string {
-	return fmt.Sprintf("HbPing: node %s ping detected from %s %s", e.Nodename, e.HbID, e.Time)
+func (e *HeartbeatPing) String() string {
+	return fmt.Sprintf("HeartbeatPing: node %s ping detected from %s %s", e.Nodename, e.HbID, e.Time)
 }
 
-func (e *HbPing) Kind() string {
-	return "HbPing"
+func (e *HeartbeatPing) Kind() string {
+	return "HeartbeatPing"
 }
 
-func (e *HbStale) String() string {
-	return fmt.Sprintf("HbStale: node %s stale detected from %s %s", e.Nodename, e.HbID, e.Time)
+func (e *HeartbeatStale) String() string {
+	return fmt.Sprintf("HeartbeatStale: node %s stale detected from %s %s", e.Nodename, e.HbID, e.Time)
 }
 
-func (e *HbStale) Kind() string {
-	return "HbStale"
+func (e *HeartbeatStale) Kind() string {
+	return "HeartbeatStale"
 }
 
 func (e *InstanceConfigDeleted) Kind() string {

--- a/daemon/nmon/main.go
+++ b/daemon/nmon/main.go
@@ -314,7 +314,7 @@ func (t *Manager) startSubscriptions() {
 	sub.AddFilter(&msgbus.DaemonListenerUpdated{})
 
 	sub.AddFilter(&msgbus.ForgetPeer{})
-	sub.AddFilter(&msgbus.HbMessageTypeUpdated{})
+	sub.AddFilter(&msgbus.HeartbeatMessageTypeUpdated{})
 	sub.AddFilter(&msgbus.JoinRequest{}, t.labelLocalhost)
 	sub.AddFilter(&msgbus.LeaveRequest{}, t.labelLocalhost)
 	sub.AddFilter(&msgbus.NodeConfigUpdated{}, pubsub.Label{"from", "peer"})
@@ -342,7 +342,7 @@ func (t *Manager) startRejoin() {
 	} else {
 		// Begin the rejoin state phase.
 		// Arm the re-join grace period ticker.
-		// The onHbMessageTypeUpdated() event handler can stop it.
+		// The onHeartbeatMessageTypeUpdated() event handler can stop it.
 		rejoinGracePeriod := t.nodeConfig.RejoinGracePeriod
 		t.rejoinTicker = time.NewTicker(rejoinGracePeriod)
 		t.log.Infof("rejoin grace period timer set to %s", rejoinGracePeriod)
@@ -429,8 +429,8 @@ func (t *Manager) worker() {
 				t.onForgetPeer(c)
 			case *msgbus.JoinRequest:
 				t.onJoinRequest(c)
-			case *msgbus.HbMessageTypeUpdated:
-				t.onHbMessageTypeUpdated(c)
+			case *msgbus.HeartbeatMessageTypeUpdated:
+				t.onHeartbeatMessageTypeUpdated(c)
 			case *msgbus.NodeConfigUpdated:
 				t.onPeerNodeConfigUpdated(c)
 			case *msgbus.NodeMonitorDeleted:

--- a/daemon/nmon/main_cmd.go
+++ b/daemon/nmon/main_cmd.go
@@ -367,7 +367,7 @@ func missingNodes(nodes, joinedNodes []string) []string {
 	return l
 }
 
-func (t *Manager) onHbMessageTypeUpdated(c *msgbus.HbMessageTypeUpdated) {
+func (t *Manager) onHeartbeatMessageTypeUpdated(c *msgbus.HeartbeatMessageTypeUpdated) {
 	if t.state.State != node.MonitorStateRejoin {
 		return
 	}


### PR DESCRIPTION
### Description

This pull request includes the following changes:

- Renamed all `Hb*` structs and methods to `Heartbeat*` for improved readability and to align with their intended purpose in the heartbeat domain.
- Updated the `DaemonHeartbeatUpdated` JSON field name from `"hb"` to `"heartbeat"` for better clarity in data representation.
- Removed the `HbStatusUpdated` event and its associated logic as it is no longer necessary for the current implementation. 

These changes enhance code clarity and streamline functionality by removing outdated or unclear items. 
