### PR TITLE
Add the "bitmap" kw to the disk.md driver

### DIFF
--- a/drivers/resdiskmd/main.go
+++ b/drivers/resdiskmd/main.go
@@ -27,15 +27,16 @@ import (
 type (
 	T struct {
 		resdisk.T
-		UUID   string      `json:"uuid"`
-		Size   string      `json:"size"`
-		Spares int         `json:"spares"`
+		Bitmap string      `json:"bitmap"`
 		Chunk  *int64      `json:"chunk"`
+		Devs   []string    `json:"devs"`
 		Layout string      `json:"layout"`
 		Level  string      `json:"level"`
-		Devs   []string    `json:"devs"`
-		Path   naming.Path `json:"path"`
 		Nodes  []string    `json:"nodes"`
+		Path   naming.Path `json:"path"`
+		Size   string      `json:"size"`
+		Spares int         `json:"spares"`
+		UUID   string      `json:"uuid"`
 	}
 	MDDriver interface {
 		Activate() error
@@ -49,7 +50,7 @@ type (
 		DisableAutoActivation() error
 	}
 	MDDriverProvisioner interface {
-		Create(level string, devs []string, spares int, layout string, chunk *int64) error
+		Create(level string, devs []string, spares int, layout string, chunk *int64, bitmap string) error
 		Remove() error
 		Wipe() error
 	}
@@ -179,7 +180,7 @@ func (t *T) ProvisionAsLeader(ctx context.Context) error {
 		t.Log().Infof("md is already created")
 		return nil
 	}
-	if err := devIntf.Create(t.Level, t.Devs, t.Spares, t.Layout, t.Chunk); err != nil {
+	if err := devIntf.Create(t.Level, t.Devs, t.Spares, t.Layout, t.Chunk, t.Bitmap); err != nil {
 		return err
 	}
 	actionrollback.Register(ctx, func(ctx context.Context) error {

--- a/drivers/resdiskmd/manifest.go
+++ b/drivers/resdiskmd/manifest.go
@@ -77,6 +77,14 @@ func (t *T) Manifest() *manifest.T {
 			Scopable:     true,
 			Text:         keywords.NewText(fs, "text/kw/spares"),
 		},
+		keywords.Keyword{
+			Attr:         "Bitmap",
+			Example:      "internal",
+			Option:       "bitmap",
+			Provisioning: true,
+			Scopable:     true,
+			Text:         keywords.NewText(fs, "text/kw/bitmap"),
+		},
 	)
 	return m
 }

--- a/drivers/resdiskmd/text/kw/bitmap
+++ b/drivers/resdiskmd/text/kw/bitmap
@@ -1,0 +1,1 @@
+'none' disables the write-intent bitmap, 'internal' writes the bitmap on the md legs, a file path may write the bitmap to a file (deprecated upstream).

--- a/util/md/main.go
+++ b/util/md/main.go
@@ -387,7 +387,7 @@ func (t T) devpathFromName() string {
 	return "/dev/md/" + t.name
 }
 
-func (t *T) Create(level string, devs []string, spares int, layout string, chunk *int64) error {
+func (t *T) Create(level string, devs []string, spares int, layout string, chunk *int64, bitmap string) error {
 	dataDevsCount := len(devs) - spares
 	if dataDevsCount < 1 {
 		return fmt.Errorf("at least 1 device must be set in the 'devs' provisioning")
@@ -410,6 +410,9 @@ func (t *T) Create(level string, devs []string, spares int, layout string, chunk
 	}
 	if layout != "" {
 		args = append(args, "-p", layout)
+	}
+	if bitmap == "none" || bitmap == "internal" {
+		args = append(args, "--bitmap="+bitmap)
 	}
 	args = append(args, devs...)
 


### PR DESCRIPTION
mdadm removed the auto creation of bitmaps on big disks.

Add this provisioning keyword to let users decide if they want to keep using a bitmap for their md resources.