### PR TITLE
[om,ox] Remove unused '--section' option

### DIFF
--- a/core/om/factory.go
+++ b/core/om/factory.go
@@ -3255,7 +3255,6 @@ func newCmdNodeUnset() *cobra.Command {
 	commoncmd.FlagsLock(flags, &options.OptsLock)
 	commoncmd.FlagKeywords(flags, &options.Keywords)
 	commoncmd.FlagNodeSelector(flags, &options.NodeSelector)
-	commoncmd.FlagSections(flags, &options.Sections)
 	flagLocal(flags, &options.Local)
 	return cmd
 }
@@ -3323,7 +3322,6 @@ func newCmdObjectUnset(kind string) *cobra.Command {
 	addFlagsGlobal(flags, &options.OptsGlobal)
 	commoncmd.FlagsLock(flags, &options.OptsLock)
 	commoncmd.FlagKeywords(flags, &options.Keywords)
-	commoncmd.FlagSections(flags, &options.Sections)
 	flagLocal(flags, &options.Local)
 	return cmd
 }

--- a/core/ox/factory.go
+++ b/core/ox/factory.go
@@ -3019,7 +3019,6 @@ func newCmdNodeUnset() *cobra.Command {
 	commoncmd.FlagsLock(flags, &options.OptsLock)
 	commoncmd.FlagKeywords(flags, &options.Keywords)
 	commoncmd.FlagNodeSelector(flags, &options.NodeSelector)
-	commoncmd.FlagSections(flags, &options.Sections)
 	return cmd
 }
 
@@ -3125,7 +3124,6 @@ func newCmdObjectUnset(kind string) *cobra.Command {
 	addFlagsGlobal(flags, &options.OptsGlobal)
 	commoncmd.FlagsLock(flags, &options.OptsLock)
 	commoncmd.FlagKeywords(flags, &options.Keywords)
-	commoncmd.FlagSections(flags, &options.Sections)
 	return cmd
 }
 


### PR DESCRIPTION
This pull request removes unused `--section` calls from factory files `om xx unset`, specifically the hidden `CmdNodeUnset` and `CmdObjectUnset`. This change is necessary as the `--section` option was not present in b2.1. In v3, configuration section removal is handled through the `config update --delete <section>` command.