### PR TITLE
Support hb.ucast port scoping and fix the missed reconfiguration

### DIFF
--- a/core/hbcfg/main.go
+++ b/core/hbcfg/main.go
@@ -170,6 +170,14 @@ func (t *T) GetInt(s string) int {
 	return t.Config().GetInt(k)
 }
 
+func (t *T) GetIntAs(s, impersonate string) int {
+	k := key.New(t.name, s)
+	if i, err := t.Config().EvalAs(k, impersonate); err == nil {
+		return i.(int)
+	}
+	return 0
+}
+
 func (t *T) GetDuration(s string, defaultValue time.Duration) time.Duration {
 	k := key.New(t.name, s)
 	found := t.Config().GetDuration(k)

--- a/daemon/hb/hbucast/hbrx.go
+++ b/daemon/hb/hbucast/hbrx.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -76,6 +77,7 @@ func (t *rx) Stop() error {
 }
 
 func (t *rx) streamPeerDesc(addr string) string {
+	addr, _, _ = strings.Cut(addr, ":")
 	if len(t.addr) > 0 {
 		if t.intf != "" {
 			return fmt.Sprintf("%s:%s@%s ← %s", t.addr, t.port, t.intf, addr)
@@ -123,6 +125,7 @@ func (t *rx) Start(cmdC chan<- interface{}, msgC chan<- *hbtype.Msg) error {
 				Timeout:  t.timeout,
 				Desc:     t.streamPeerDesc(addr),
 			}
+			addr, _, _ := strings.Cut(addr, ":")
 			addrs, err := resolver.LookupHost(ctx, addr)
 			if err != nil {
 				continue

--- a/daemon/hb/hbucast/hbtx.go
+++ b/daemon/hb/hbucast/hbtx.go
@@ -59,15 +59,15 @@ func (t *tx) Stop() error {
 func (t *tx) streamPeerDesc(addr string) string {
 	if len(t.localIP) > 0 {
 		if t.intf != "" {
-			return fmt.Sprintf("%s@%s → %s:%s", t.localIP, t.intf, addr, t.port)
+			return fmt.Sprintf("%s@%s → %s", t.localIP, t.intf, addr)
 		} else {
-			return fmt.Sprintf("%s → %s:%s", t.localIP, addr, t.port)
+			return fmt.Sprintf("%s → %s", t.localIP, addr)
 		}
 	} else {
 		if t.intf != "" {
-			return fmt.Sprintf("@%s → %s:%s", t.intf, addr, t.port)
+			return fmt.Sprintf("@%s → %s", t.intf, addr)
 		} else {
-			return fmt.Sprintf("→ %s:%s", addr, t.port)
+			return fmt.Sprintf("→ %s", addr)
 		}
 	}
 	return ""
@@ -175,7 +175,7 @@ func (t *tx) send(node, addr string, b []byte) {
 		LocalAddr: &localAddr,
 	}
 	send := func() error {
-		conn, err := dialer.Dial("tcp", addr+":"+t.port)
+		conn, err := dialer.Dial("tcp", addr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* b2.1 supports port scoping... not to encourage, but port to avoid migration hassles.

* add the port to the nodeMap to detect port changes, even in peer scoped configs

Example:

	$ sudo om daemon hb status --name hb#1
	STATUS  NODE    PEER    DESC
	✅      dev2n3  dev2n1  11.29.1.13:9993 ← 11.29.1.11
	✅      dev2n3  dev2n2  11.29.1.13:9993 ← 11.29.1.12
	✅      dev2n3  dev2n1  → 11.29.1.11:9991
	✅      dev2n3  dev2n2  → 11.29.1.12:9992
	✅      dev2n1  dev2n2  11.29.1.11:9991 ← 11.29.1.12
	✅      dev2n1  dev2n3  11.29.1.11:9991 ← 11.29.1.13
	✅      dev2n1  dev2n2  → 11.29.1.12:9992
	✅      dev2n1  dev2n3  → 11.29.1.13:9993
	✅      dev2n2  dev2n1  11.29.1.12:9992 ← 11.29.1.11
	✅      dev2n2  dev2n3  11.29.1.12:9992 ← 11.29.1.13
	✅      dev2n2  dev2n1  → 11.29.1.11:9991
	✅      dev2n2  dev2n3  → 11.29.1.13:9993