### PR TITLE
Add API endpoints to expose keyword definitions

### DIFF
--- a/core/keywords/keywords.go
+++ b/core/keywords/keywords.go
@@ -231,6 +231,15 @@ func (t Store) KeywordDoc(section, typ, option string, kind naming.Kind, depth i
 	return kw.Doc(depth), nil
 }
 
+func (t Store) DriverKeywords(section, typ string, kind naming.Kind) ([]Keyword, error) {
+	index := Index{section, typ}
+	m, ok := t.KeywordsByDriver(kind)[index]
+	if !ok {
+		return nil, fmt.Errorf("driver not found")
+	}
+	return maps.Values(m), nil
+}
+
 func (t Store) DriverDoc(section, typ string, kind naming.Kind, depth int) (string, error) {
 	depth += 1
 	index := Index{section, typ}

--- a/core/keywords/keywords.go
+++ b/core/keywords/keywords.go
@@ -104,6 +104,21 @@ const (
 	InheritHead
 )
 
+func (t Inherit) String() string {
+	switch t {
+	case InheritLeaf2Head:
+		return "leaf2head"
+	case InheritHead2Leaf:
+		return "head2leaf"
+	case InheritLeaf:
+		return "leaf"
+	case InheritHead:
+		return "head"
+	default:
+		return "unknown"
+	}
+}
+
 func NewText(fs embed.FS, path string) Text {
 	return Text{fs, path}
 }

--- a/core/object/core_doc.go
+++ b/core/object/core_doc.go
@@ -10,7 +10,7 @@ import (
 	"github.com/opensvc/om3/util/key"
 )
 
-func storeWithDriverKeywords(kind naming.Kind) keywords.Store {
+func KeywordStoreWithDrivers(kind naming.Kind) keywords.Store {
 	var store keywords.Store
 	if kind == naming.KindCcfg {
 		store = append(store, ccfgKeywordStore...)
@@ -38,7 +38,7 @@ func storeWithDriverKeywords(kind naming.Kind) keywords.Store {
 }
 
 func (t *core) Doc(drvStr, kwStr string, depth int) (string, error) {
-	store := storeWithDriverKeywords(t.path.Kind)
+	store := KeywordStoreWithDrivers(t.path.Kind)
 	switch {
 	case drvStr == "" && kwStr == "":
 		return store.Doc(t.path.Kind, depth)

--- a/core/object/node_doc.go
+++ b/core/object/node_doc.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (t *Node) Doc(drvStr, kwStr string, depth int) (string, error) {
-	store := nodeKeywordStore
+	store := NodeKeywordStore
 	switch {
 	case drvStr == "" && kwStr == "":
 		return store.Doc(naming.KindInvalid, depth)

--- a/core/object/node_keywords.go
+++ b/core/object/node_keywords.go
@@ -1516,8 +1516,8 @@ var nodeCommonKeywords = []keywords.Keyword{
 	},
 }
 
-var nodeKeywordStore = keywords.Store(append(nodePrivateKeywords, nodeCommonKeywords...))
+var NodeKeywordStore = keywords.Store(append(nodePrivateKeywords, nodeCommonKeywords...))
 
 func (t Node) KeywordLookup(k key.T, sectionType string) keywords.Keyword {
-	return keywordLookup(nodeKeywordStore, k, naming.KindInvalid, sectionType)
+	return keywordLookup(NodeKeywordStore, k, naming.KindInvalid, sectionType)
 }

--- a/daemon/api/api.yaml
+++ b/daemon/api/api.yaml
@@ -452,6 +452,86 @@ paths:
       tags:
         - node
 
+  /api/cluster/config/keywords:
+    get:
+      operationId: GetClusterConfigKeywords
+      description: |
+        Return the list of supported keywords in cluster.conf
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeywordDefinitionList'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        500:
+          $ref: '#/components/responses/500'
+      security:
+        - basicAuth: [ ]
+        - bearerAuth: [ ]
+      tags:
+        - cluster
+
+  /api/node/{nodename}/config/keywords:
+    get:
+      operationId: GetNodeConfigKeywords
+      description: |
+        Return the list of supported keywords in node
+      parameters:
+        - $ref: '#/components/parameters/inPathNodeName'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeywordDefinitionList'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        500:
+          $ref: '#/components/responses/500'
+      security:
+        - basicAuth: [ ]
+        - bearerAuth: [ ]
+      tags:
+        - node
+
+  /api/object/path/{namespace}/{kind}/{name}/config/keywords:
+    get:
+      operationId: GetObjectConfigKeywords
+      description: |
+        Return the list of supported keywords in object
+      tags:
+        - object / svc
+        - object / vol
+        - object / cfg
+        - object / sec
+        - object / usr
+      security:
+        - basicAuth: [ ]
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/inPathNamespace'
+        - $ref: '#/components/parameters/inPathKind'
+        - $ref: '#/components/parameters/inPathName'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeywordDefinitionList'
+        401:
+          $ref: '#/components/responses/401'
+        500:
+          $ref: '#/components/responses/500'
+
   /api/node/name/{nodename}/daemon/action/restart:
     post:
       description: |
@@ -3085,7 +3165,7 @@ paths:
           $ref: '#/components/responses/409'
         500:
           $ref: '#/components/responses/500'
- 
+
   /api/object/path/{namespace}/{kind}/{name}/data/keys:
     get:
       description: |
@@ -4201,11 +4281,27 @@ components:
             - CapabilityList
         items:
           $ref: '#/components/schemas/CapabilityItems'
+    KeywordDefinitionList:
+      type: object
+      required:
+        - kind
+        - items
+      properties:
+        kind:
+          type: string
+          enum:
+            - KeywordDefinitionList
+        items:
+          $ref: '#/components/schemas/KeywordDefinitionItems'
 
     CapabilityItems:
       type: array
       items:
         $ref: '#/components/schemas/CapabilityItem'
+    KeywordDefinitionItems:
+      type: array
+      items:
+        $ref: '#/components/schemas/KeywordDefinitionItem'
 
     CapabilityItem:
       type: object
@@ -4222,6 +4318,56 @@ components:
           $ref: '#/components/schemas/NodeMeta'
         data:
           $ref: '#/components/schemas/Capability'
+    KeywordDefinitionItem:
+      type: object
+      required:
+        - section
+        - option
+      properties:
+        section:
+          type: string
+        option:
+          type: string
+        scopable:
+          type: boolean
+        converter:
+          type: string
+        text:
+          type: string
+        defaultText:
+          type: string
+        example:
+          type: string
+        default:
+          type: string
+        defaultOption:
+          type: string
+        candidates:
+          type: array
+          items:
+            type: string
+        depends:
+          type : array
+          items:
+            type: string
+        kind:
+          type: array
+          items:
+            type: string
+        provisioning:
+          type: boolean
+        types:
+          type: array
+          items:
+            type: string
+        aliases:
+          type: array
+          items:
+            type: string
+        inherit:
+          type: string
+        deprecated:
+          type: string
 
     Capability:
       type: object
@@ -4675,7 +4821,7 @@ components:
         expired_at:
           type: string
           format: date-time
-    
+
     DriverList:
       type: object
       required:

--- a/daemon/api/api.yaml
+++ b/daemon/api/api.yaml
@@ -457,6 +457,10 @@ paths:
       operationId: GetClusterConfigKeywords
       description: |
         Return the list of supported keywords in cluster.conf
+      parameters:
+        - $ref: '#/components/parameters/inQueryDriver'
+        - $ref: '#/components/parameters/inQuerySection'
+        - $ref: '#/components/parameters/inQueryOption'
       responses:
         200:
           description: OK
@@ -476,13 +480,16 @@ paths:
       tags:
         - cluster
 
-  /api/node/{nodename}/config/keywords:
+  /api/node/name/{nodename}/config/keywords:
     get:
       operationId: GetNodeConfigKeywords
       description: |
         Return the list of supported keywords in node
       parameters:
         - $ref: '#/components/parameters/inPathNodeName'
+        - $ref: '#/components/parameters/inQueryDriver'
+        - $ref: '#/components/parameters/inQuerySection'
+        - $ref: '#/components/parameters/inQueryOption'
       responses:
         200:
           description: OK
@@ -507,6 +514,13 @@ paths:
       operationId: GetObjectConfigKeywords
       description: |
         Return the list of supported keywords in object
+      parameters:
+        - $ref: '#/components/parameters/inPathNamespace'
+        - $ref: '#/components/parameters/inPathKind'
+        - $ref: '#/components/parameters/inPathName'
+        - $ref: '#/components/parameters/inQueryDriver'
+        - $ref: '#/components/parameters/inQuerySection'
+        - $ref: '#/components/parameters/inQueryOption'
       tags:
         - object / svc
         - object / vol
@@ -516,10 +530,6 @@ paths:
       security:
         - basicAuth: [ ]
         - bearerAuth: [ ]
-      parameters:
-        - $ref: '#/components/parameters/inPathNamespace'
-        - $ref: '#/components/parameters/inPathKind'
-        - $ref: '#/components/parameters/inPathName'
       responses:
         200:
           description: OK
@@ -7267,6 +7277,30 @@ components:
       schema:
         type: string
         format: duration
+
+    inQueryDriver:
+      in: query
+      name: driver
+      description: show only keywords of this driver
+      schema:
+        type: string
+        example: fs.ext4
+
+    inQuerySection:   
+      in: query
+      name: section
+      description: show supported keywords of this configuration section
+      schema:
+        type: string
+        example: fs#2
+
+    inQueryOption:
+      in: query
+      name: option
+      description: show the keyword referenced by section and option
+      schema:
+        type: string
+        example: fs#2
 
     Duration:
       name: duration

--- a/daemon/api/codegen_client_gen.go
+++ b/daemon/api/codegen_client_gen.go
@@ -119,6 +119,9 @@ type ClientInterface interface {
 	// PutClusterConfigFileWithBody request with any body
 	PutClusterConfigFileWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetClusterConfigKeywords request
+	GetClusterConfigKeywords(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// PostClusterJoin request
 	PostClusterJoin(ctx context.Context, params *PostClusterJoinParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -378,6 +381,9 @@ type ClientInterface interface {
 	// GetNodeSystemUser request
 	GetNodeSystemUser(ctx context.Context, nodename InPathNodeName, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetNodeConfigKeywords request
+	GetNodeConfigKeywords(ctx context.Context, nodename InPathNodeName, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetObjects request
 	GetObjects(ctx context.Context, params *GetObjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -447,6 +453,9 @@ type ClientInterface interface {
 
 	// PutObjectConfigFileWithBody request with any body
 	PutObjectConfigFileWithBody(ctx context.Context, namespace InPathNamespace, kind InPathKind, name InPathName, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetObjectConfigKeywords request
+	GetObjectConfigKeywords(ctx context.Context, namespace InPathNamespace, kind InPathKind, name InPathName, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetObjectData request
 	GetObjectData(ctx context.Context, namespace InPathNamespace, kind InPathKind, name InPathName, params *GetObjectDataParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -611,6 +620,18 @@ func (c *Client) GetClusterConfigFile(ctx context.Context, reqEditors ...Request
 
 func (c *Client) PutClusterConfigFileWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPutClusterConfigFileRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetClusterConfigKeywords(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetClusterConfigKeywordsRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -1677,6 +1698,18 @@ func (c *Client) GetNodeSystemUser(ctx context.Context, nodename InPathNodeName,
 	return c.Client.Do(req)
 }
 
+func (c *Client) GetNodeConfigKeywords(ctx context.Context, nodename InPathNodeName, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetNodeConfigKeywordsRequest(c.Server, nodename)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetObjects(ctx context.Context, params *GetObjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetObjectsRequest(c.Server, params)
 	if err != nil {
@@ -1955,6 +1988,18 @@ func (c *Client) PostObjectConfigFileWithBody(ctx context.Context, namespace InP
 
 func (c *Client) PutObjectConfigFileWithBody(ctx context.Context, namespace InPathNamespace, kind InPathKind, name InPathName, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPutObjectConfigFileRequestWithBody(c.Server, namespace, kind, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetObjectConfigKeywords(ctx context.Context, namespace InPathNamespace, kind InPathKind, name InPathName, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetObjectConfigKeywordsRequest(c.Server, namespace, kind, name)
 	if err != nil {
 		return nil, err
 	}
@@ -2627,6 +2672,33 @@ func NewPutClusterConfigFileRequestWithBody(server string, contentType string, b
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetClusterConfigKeywordsRequest generates requests for GetClusterConfigKeywords
+func NewGetClusterConfigKeywordsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/cluster/config/keywords")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -8911,6 +8983,40 @@ func NewGetNodeSystemUserRequest(server string, nodename InPathNodeName) (*http.
 	return req, nil
 }
 
+// NewGetNodeConfigKeywordsRequest generates requests for GetNodeConfigKeywords
+func NewGetNodeConfigKeywordsRequest(server string, nodename InPathNodeName) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "nodename", runtime.ParamLocationPath, nodename)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/node/%s/config/keywords", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetObjectsRequest generates requests for GetObjects
 func NewGetObjectsRequest(server string, params *GetObjectsParams) (*http.Request, error) {
 	var err error
@@ -10197,6 +10303,54 @@ func NewPutObjectConfigFileRequestWithBody(server string, namespace InPathNamesp
 	return req, nil
 }
 
+// NewGetObjectConfigKeywordsRequest generates requests for GetObjectConfigKeywords
+func NewGetObjectConfigKeywordsRequest(server string, namespace InPathNamespace, kind InPathKind, name InPathName) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespace", runtime.ParamLocationPath, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "kind", runtime.ParamLocationPath, kind)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/object/path/%s/%s/%s/config/keywords", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetObjectDataRequest generates requests for GetObjectData
 func NewGetObjectDataRequest(server string, namespace InPathNamespace, kind InPathKind, name InPathName, params *GetObjectDataParams) (*http.Request, error) {
 	var err error
@@ -11197,6 +11351,9 @@ type ClientWithResponsesInterface interface {
 	// PutClusterConfigFileWithBodyWithResponse request with any body
 	PutClusterConfigFileWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutClusterConfigFileResponse, error)
 
+	// GetClusterConfigKeywordsWithResponse request
+	GetClusterConfigKeywordsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetClusterConfigKeywordsResponse, error)
+
 	// PostClusterJoinWithResponse request
 	PostClusterJoinWithResponse(ctx context.Context, params *PostClusterJoinParams, reqEditors ...RequestEditorFn) (*PostClusterJoinResponse, error)
 
@@ -11456,6 +11613,9 @@ type ClientWithResponsesInterface interface {
 	// GetNodeSystemUserWithResponse request
 	GetNodeSystemUserWithResponse(ctx context.Context, nodename InPathNodeName, reqEditors ...RequestEditorFn) (*GetNodeSystemUserResponse, error)
 
+	// GetNodeConfigKeywordsWithResponse request
+	GetNodeConfigKeywordsWithResponse(ctx context.Context, nodename InPathNodeName, reqEditors ...RequestEditorFn) (*GetNodeConfigKeywordsResponse, error)
+
 	// GetObjectsWithResponse request
 	GetObjectsWithResponse(ctx context.Context, params *GetObjectsParams, reqEditors ...RequestEditorFn) (*GetObjectsResponse, error)
 
@@ -11525,6 +11685,9 @@ type ClientWithResponsesInterface interface {
 
 	// PutObjectConfigFileWithBodyWithResponse request with any body
 	PutObjectConfigFileWithBodyWithResponse(ctx context.Context, namespace InPathNamespace, kind InPathKind, name InPathName, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutObjectConfigFileResponse, error)
+
+	// GetObjectConfigKeywordsWithResponse request
+	GetObjectConfigKeywordsWithResponse(ctx context.Context, namespace InPathNamespace, kind InPathKind, name InPathName, reqEditors ...RequestEditorFn) (*GetObjectConfigKeywordsResponse, error)
 
 	// GetObjectDataWithResponse request
 	GetObjectDataWithResponse(ctx context.Context, namespace InPathNamespace, kind InPathKind, name InPathName, params *GetObjectDataParams, reqEditors ...RequestEditorFn) (*GetObjectDataResponse, error)
@@ -11835,6 +11998,31 @@ func (r PutClusterConfigFileResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PutClusterConfigFileResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetClusterConfigKeywordsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *KeywordDefinitionList
+	JSON400      *N400
+	JSON401      *N401
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r GetClusterConfigKeywordsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetClusterConfigKeywordsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -13973,6 +14161,31 @@ func (r GetNodeSystemUserResponse) StatusCode() int {
 	return 0
 }
 
+type GetNodeConfigKeywordsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *KeywordDefinitionList
+	JSON400      *N400
+	JSON401      *N401
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r GetNodeConfigKeywordsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetNodeConfigKeywordsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetObjectsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -14578,6 +14791,30 @@ func (r PutObjectConfigFileResponse) StatusCode() int {
 	return 0
 }
 
+type GetObjectConfigKeywordsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *KeywordDefinitionList
+	JSON401      *N401
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r GetObjectConfigKeywordsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetObjectConfigKeywordsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetObjectDataResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -15077,6 +15314,15 @@ func (c *ClientWithResponses) PutClusterConfigFileWithBodyWithResponse(ctx conte
 		return nil, err
 	}
 	return ParsePutClusterConfigFileResponse(rsp)
+}
+
+// GetClusterConfigKeywordsWithResponse request returning *GetClusterConfigKeywordsResponse
+func (c *ClientWithResponses) GetClusterConfigKeywordsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetClusterConfigKeywordsResponse, error) {
+	rsp, err := c.GetClusterConfigKeywords(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetClusterConfigKeywordsResponse(rsp)
 }
 
 // PostClusterJoinWithResponse request returning *PostClusterJoinResponse
@@ -15866,6 +16112,15 @@ func (c *ClientWithResponses) GetNodeSystemUserWithResponse(ctx context.Context,
 	return ParseGetNodeSystemUserResponse(rsp)
 }
 
+// GetNodeConfigKeywordsWithResponse request returning *GetNodeConfigKeywordsResponse
+func (c *ClientWithResponses) GetNodeConfigKeywordsWithResponse(ctx context.Context, nodename InPathNodeName, reqEditors ...RequestEditorFn) (*GetNodeConfigKeywordsResponse, error) {
+	rsp, err := c.GetNodeConfigKeywords(ctx, nodename, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetNodeConfigKeywordsResponse(rsp)
+}
+
 // GetObjectsWithResponse request returning *GetObjectsResponse
 func (c *ClientWithResponses) GetObjectsWithResponse(ctx context.Context, params *GetObjectsParams, reqEditors ...RequestEditorFn) (*GetObjectsResponse, error) {
 	rsp, err := c.GetObjects(ctx, params, reqEditors...)
@@ -16078,6 +16333,15 @@ func (c *ClientWithResponses) PutObjectConfigFileWithBodyWithResponse(ctx contex
 		return nil, err
 	}
 	return ParsePutObjectConfigFileResponse(rsp)
+}
+
+// GetObjectConfigKeywordsWithResponse request returning *GetObjectConfigKeywordsResponse
+func (c *ClientWithResponses) GetObjectConfigKeywordsWithResponse(ctx context.Context, namespace InPathNamespace, kind InPathKind, name InPathName, reqEditors ...RequestEditorFn) (*GetObjectConfigKeywordsResponse, error) {
+	rsp, err := c.GetObjectConfigKeywords(ctx, namespace, kind, name, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetObjectConfigKeywordsResponse(rsp)
 }
 
 // GetObjectDataWithResponse request returning *GetObjectDataResponse
@@ -16781,6 +17045,53 @@ func ParsePutClusterConfigFileResponse(rsp *http.Response) (*PutClusterConfigFil
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetClusterConfigKeywordsResponse parses an HTTP response from a GetClusterConfigKeywordsWithResponse call
+func ParseGetClusterConfigKeywordsResponse(rsp *http.Response) (*GetClusterConfigKeywordsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetClusterConfigKeywordsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest KeywordDefinitionList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest N500
@@ -21094,6 +21405,53 @@ func ParseGetNodeSystemUserResponse(rsp *http.Response) (*GetNodeSystemUserRespo
 	return response, nil
 }
 
+// ParseGetNodeConfigKeywordsResponse parses an HTTP response from a GetNodeConfigKeywordsWithResponse call
+func ParseGetNodeConfigKeywordsResponse(rsp *http.Response) (*GetNodeConfigKeywordsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetNodeConfigKeywordsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest KeywordDefinitionList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetObjectsResponse parses an HTTP response from a GetObjectsWithResponse call
 func ParseGetObjectsResponse(rsp *http.Response) (*GetObjectsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -22500,6 +22858,46 @@ func ParsePutObjectConfigFileResponse(rsp *http.Response) (*PutObjectConfigFileR
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetObjectConfigKeywordsResponse parses an HTTP response from a GetObjectConfigKeywordsWithResponse call
+func ParseGetObjectConfigKeywordsResponse(rsp *http.Response) (*GetObjectConfigKeywordsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetObjectConfigKeywordsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest KeywordDefinitionList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest N500

--- a/daemon/api/codegen_server_gen.go
+++ b/daemon/api/codegen_server_gen.go
@@ -51,6 +51,9 @@ type ServerInterface interface {
 	// (PUT /api/cluster/config/file)
 	PutClusterConfigFile(ctx echo.Context) error
 
+	// (GET /api/cluster/config/keywords)
+	GetClusterConfigKeywords(ctx echo.Context) error
+
 	// (POST /api/cluster/join)
 	PostClusterJoin(ctx echo.Context, params PostClusterJoinParams) error
 
@@ -300,6 +303,9 @@ type ServerInterface interface {
 	// (GET /api/node/name/{nodename}/system/user)
 	GetNodeSystemUser(ctx echo.Context, nodename InPathNodeName) error
 
+	// (GET /api/node/{nodename}/config/keywords)
+	GetNodeConfigKeywords(ctx echo.Context, nodename InPathNodeName) error
+
 	// (GET /api/object)
 	GetObjects(ctx echo.Context, params GetObjectsParams) error
 
@@ -365,6 +371,9 @@ type ServerInterface interface {
 
 	// (PUT /api/object/path/{namespace}/{kind}/{name}/config/file)
 	PutObjectConfigFile(ctx echo.Context, namespace InPathNamespace, kind InPathKind, name InPathName) error
+
+	// (GET /api/object/path/{namespace}/{kind}/{name}/config/keywords)
+	GetObjectConfigKeywords(ctx echo.Context, namespace InPathNamespace, kind InPathKind, name InPathName) error
 
 	// (GET /api/object/path/{namespace}/{kind}/{name}/data)
 	GetObjectData(ctx echo.Context, namespace InPathNamespace, kind InPathKind, name InPathName, params GetObjectDataParams) error
@@ -619,6 +628,19 @@ func (w *ServerInterfaceWrapper) PutClusterConfigFile(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.PutClusterConfigFile(ctx)
+	return err
+}
+
+// GetClusterConfigKeywords converts echo context to params.
+func (w *ServerInterfaceWrapper) GetClusterConfigKeywords(ctx echo.Context) error {
+	var err error
+
+	ctx.Set(BasicAuthScopes, []string{})
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetClusterConfigKeywords(ctx)
 	return err
 }
 
@@ -4125,6 +4147,26 @@ func (w *ServerInterfaceWrapper) GetNodeSystemUser(ctx echo.Context) error {
 	return err
 }
 
+// GetNodeConfigKeywords converts echo context to params.
+func (w *ServerInterfaceWrapper) GetNodeConfigKeywords(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "nodename" -------------
+	var nodename InPathNodeName
+
+	err = runtime.BindStyledParameterWithOptions("simple", "nodename", ctx.Param("nodename"), &nodename, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter nodename: %s", err))
+	}
+
+	ctx.Set(BasicAuthScopes, []string{})
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetNodeConfigKeywords(ctx, nodename)
+	return err
+}
+
 // GetObjects converts echo context to params.
 func (w *ServerInterfaceWrapper) GetObjects(ctx echo.Context) error {
 	var err error
@@ -4965,6 +5007,42 @@ func (w *ServerInterfaceWrapper) PutObjectConfigFile(ctx echo.Context) error {
 	return err
 }
 
+// GetObjectConfigKeywords converts echo context to params.
+func (w *ServerInterfaceWrapper) GetObjectConfigKeywords(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "namespace" -------------
+	var namespace InPathNamespace
+
+	err = runtime.BindStyledParameterWithOptions("simple", "namespace", ctx.Param("namespace"), &namespace, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter namespace: %s", err))
+	}
+
+	// ------------- Path parameter "kind" -------------
+	var kind InPathKind
+
+	err = runtime.BindStyledParameterWithOptions("simple", "kind", ctx.Param("kind"), &kind, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter kind: %s", err))
+	}
+
+	// ------------- Path parameter "name" -------------
+	var name InPathName
+
+	err = runtime.BindStyledParameterWithOptions("simple", "name", ctx.Param("name"), &name, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter name: %s", err))
+	}
+
+	ctx.Set(BasicAuthScopes, []string{})
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetObjectConfigKeywords(ctx, namespace, kind, name)
+	return err
+}
+
 // GetObjectData converts echo context to params.
 func (w *ServerInterfaceWrapper) GetObjectData(ctx echo.Context) error {
 	var err error
@@ -5539,6 +5617,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.PATCH(baseURL+"/api/cluster/config", wrapper.PatchClusterConfig)
 	router.GET(baseURL+"/api/cluster/config/file", wrapper.GetClusterConfigFile)
 	router.PUT(baseURL+"/api/cluster/config/file", wrapper.PutClusterConfigFile)
+	router.GET(baseURL+"/api/cluster/config/keywords", wrapper.GetClusterConfigKeywords)
 	router.POST(baseURL+"/api/cluster/join", wrapper.PostClusterJoin)
 	router.POST(baseURL+"/api/cluster/leave", wrapper.PostClusterLeave)
 	router.GET(baseURL+"/api/cluster/status", wrapper.GetClusterStatus)
@@ -5622,6 +5701,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/api/node/name/:nodename/system/san/initiator", wrapper.GetNodeSystemSANInitiator)
 	router.GET(baseURL+"/api/node/name/:nodename/system/san/path", wrapper.GetNodeSystemSANPath)
 	router.GET(baseURL+"/api/node/name/:nodename/system/user", wrapper.GetNodeSystemUser)
+	router.GET(baseURL+"/api/node/:nodename/config/keywords", wrapper.GetNodeConfigKeywords)
 	router.GET(baseURL+"/api/object", wrapper.GetObjects)
 	router.GET(baseURL+"/api/object/path", wrapper.GetObjectPaths)
 	router.POST(baseURL+"/api/object/path/:namespace/svc/:name/disable", wrapper.PostSvcDisable)
@@ -5644,6 +5724,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/api/object/path/:namespace/:kind/:name/config/file", wrapper.GetObjectConfigFile)
 	router.POST(baseURL+"/api/object/path/:namespace/:kind/:name/config/file", wrapper.PostObjectConfigFile)
 	router.PUT(baseURL+"/api/object/path/:namespace/:kind/:name/config/file", wrapper.PutObjectConfigFile)
+	router.GET(baseURL+"/api/object/path/:namespace/:kind/:name/config/keywords", wrapper.GetObjectConfigKeywords)
 	router.GET(baseURL+"/api/object/path/:namespace/:kind/:name/data", wrapper.GetObjectData)
 	router.PATCH(baseURL+"/api/object/path/:namespace/:kind/:name/data", wrapper.PatchObjectData)
 	router.DELETE(baseURL+"/api/object/path/:namespace/:kind/:name/data/key", wrapper.DeleteObjectDataKey)
@@ -5666,241 +5747,245 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y9a3PjNrIA+ldQ2lOVzbmyPa/kJHMrtTUZZzbeTGZ87JnduhvnOBDZkrAmAQYAZSsp",
-	"//dbePElgCIl+c0vcUbEowF0N7ob/fhzFLE0YxSoFKPXf44yzHEKErj+1+HJ94dvGZ2S2QecgvolBhFx",
-	"kknC6Oj1SM4BTfMkQRmWc8SmSP9AEkBEoBjiPIIYTTlL9QeqxhiPiOr5ew58ORqP9G+vR/YTh99zwiEe",
-	"vZY8h/FIRHNIsZpXLjPVTkhO6Gx0fT0eHeYcGzCaUKX4CsXuq3++yudyDrjCaZaoz1+J0dgz5Q8LoPIt",
-	"juaerRASc6mXCaoVmgLEKBeEzvSPCZYgJMqwkKaBKPclUiMiOccSpVhGc/2jyCAiUwIxuiA0RpjGKMET",
-	"SMR+YEl6lNp6YpjiPJGj11OcCCgWNGEsAUzLFb0jiQS+uqSECKkO1S7ItPJPXnwsZycSUrE6qGmJ4Crj",
-	"IARh9DX6Ra3w11/Gen3fLXCSw6///ct+jCW+urqyP5ypsypP6OPkPxDJU4llLj5nMZYQjxUSfjdlbPXs",
-	"ih8w53ipV/6epET61pwSiTTsKGI5lYEF63Z+7Hk+Hk0ZT7EcvR4RKr9+VcJDqIQZcAMAm63b+ITNdrXt",
-	"GHk2vrLh9d3f39+v7bYg8Xff4m/g2Sv4em8SPX+x9+olfL33zcv4+d4Unj+Lv3r59UvA/9Nt59nsHUsS",
-	"dulBDv27IRg2E6FVm94e9lBF7fds9p5Q8OwFh4xpWiUC0TydAFebrUkz0f9hMwRUcgIiePpUf1sBoHrA",
-	"imWKDEfwUU+Mk1VIqGvSwhbd9zZe+IHFbbOwGJCABCLJqggQ4iSqfYAx0hdj/Md3kD/38sdjLOer0zNN",
-	"qn0AUITcehuUAMWT5+NLmPx3EJ7wtmwM10ZwiDCZW0DU6AJJhgQoZs9mAk0ZbwFFdCH8yuB1kl5Ez8dI",
-	"LKIXnYj2BBK8fJvkQgI/OvRLApH5jEiMCqHCCQUiYVJ9YFT/k6vhQheZGeacxH0kgvHoam/G9uwYJaQO",
-	"dkUiNCjEUPt1K8DdID0FGQ3eCaRMeoA7miI9AiqYFiChbz0FoIZGmB+BL9TeCxQlxMC/j46mSN/9iHFE",
-	"mcJ1GRipMgSkE4hjiM3oIVrgBuA1TFiv7bMA7t96uzot3Zjd/T0HjUNzbJbFGZNoxjHVgGPTLAUh8AxK",
-	"CaoUlnIB3ACOMswlURMhQoVUfe06i1m+EGWj0DpzB3yHQ2yhcXdSDBEaJXkMiDiEEhmjApASdwTI4HYb",
-	"vPPQ+xrirROGhVNBTOIwb+QgWM6jXteG6xPgkFPxl+djknkZ5AlLoGXzcEYQZ0nolrSfPFvzXxymo9ej",
-	"vxyUSs6BaSYO1JxeVndqlxzeHbcpAXgqn9tQhlB1L/wImMsJYOk0LD2iZdddtaO2dR5iSBmtT1NO/xOh",
-	"cWBWJZVvPKset5zmPRESKPCbXWRtlnLybSYNHVsh3LUM7CS3LnKM0g69pGGnYzG0LaPLzVPH4U+VC1sL",
-	"iJJZvllhkUiyffTb+W+aQf+WsAgncybkb4jDFDiS2Rl1t6fRXzlEQBZQ4+b7DdWtGCaw3v9V1PQmSU4T",
-	"vDBcwUtk5mt4gW8iqS5tnCQIaIQzfQtgGoEY6+XEjH4hETatFLgKpKIRIlN9Y2JxAbGSwxQDTEhEJCT6",
-	"TvRcdhZ0bTDhaQjwyH5ec3O6wbixcHhH4g0DRniYQ0hAhjcz1p+7iJOfrB1Hs2UkINIXrGTIDDFGl0TO",
-	"WS7RhOPoAqSoK5ISi4u/5PQSUwlxJ8HTLYAIPEnghCXJBEcXwYWYZufcteu2PT/QRXBvgC66bMwbioAu",
-	"CGc0VdLXAnOiIDHyvHS3vVq/kjFTTGOB4AqiXG9gxKiEK1nfrJ//v3++OfkuXS5w0merflA6PJYQXJD7",
-	"HqadQ9AEDjSCMRIRy4yIFjG6ACs6XsDykvEYcXyJtNGgnSjeMR4FIZoyHkHHozpKM+CC0ZYFkkqTdgao",
-	"GZdGZyWYld3Q5RwoshtF6Axht959dApS/1RrbpHebe13WqrlIHNOBcLoexyjE8tSgXPG99t430+wrPH6",
-	"vrbSBmIayVIyrg/NWWHXzS7WTL+eIDrN2y6tGkBqsKlDCMJ2cdkNMoe8+s5L2QLqhAd0sb8Jk3oPODb2",
-	"PK/RyHzthuY/YyHDQ6Xm69rLb/Vaq6h6RBH3yk1Yvyu3uAZPnJZ1SuLQOgpN7Fxobb9cTmFBzXOyegZN",
-	"ncbNZBQUpfVX4GiZvjFp6yT1UU9BhkUTkP3QkGVgniOclgUxwgKd5c+evYwuLvVf+MX8k9AYrswvv5pf",
-	"WGb+af6lebH5wVzGiGUoIReAvkP/z3do77tVVAcsv5vynEjRB9k7iGeddqHE1IaYVtHqJ0uNxmrsXQpv",
-	"HRYpsYSPNFkG16kanDPVohthn+YThR+h4czXdRqIHukTnoWGkXjWcQwWHIJ1G+EzFS2kkNOOxFCVKw2D",
-	"KiRLw6F3LVleqxvUmF40OC+ePVN/tCBG9fngTOGMpsuD/wgjhnfTRo85mySQmlnq6/z4k4LlxbNXq1vw",
-	"gaG3dvbr8ejV7cBTkUzMrM9vY9bPFOdyzjj5A2Iz7cvbmPYd4xMSx0DNnK9uY84PTKJ3LKd2nd/cxpxO",
-	"1PxEUmC5Pdhvb2NmpfsmJNJTfnU7GHxEJXCKE3RqzNc/KPnazH8rSHVqRCn0meIFJolS+jR/tF3VyG/4",
-	"hEiOJePmwVo7WnB160tiuI8ofm+Dwva+Ho9ynvi5cqkV/KIbjd3QvxYc0LwIqVHe5HJ+RKdsFZ4U5JxZ",
-	"OdsxbKB5qoZlGVAtOE2wIJESk7569q2ayEhflZnCQr4dY2Ve83Zxbj6tjEKEyI1Q3L5w225cGe7XZhu3",
-	"wtC+fGIXQFcBhKtMjXCOZU1KjbGEPUkCGo4bqh3qytCujw+4tzjDE5IQuVyFzr2ytE+kW7UPfSQhXR1e",
-	"KXTrcLQC3vXY2JAruNOYwYcqKayf5AOL4WfVrrk0a7PWY4wNvOsXKjq/GTTA9yB22eI9EXJ1CzeYRrRv",
-	"pJ7n1/GaM7cbY6b3bomxBZcMarUFS1MilXS1uipxHs0xnUEcEH7r1Fk09gFy+OH0BCLGvdwBC/+Tl8PM",
-	"lQ8BihiPpEx8fhsOoE40ZBuPLWBm0Ba0O/xw+m9GoTMelFvhwbTDk+8P3yQJiwovuO05leG7fXRv88Ke",
-	"Esq4fzszxmXAQaa6n7qZG2hc54UkgCiFc2KYUxVLmSyl3+pVBSJ8cJ43tBX5vfiMjJ5qdRP0xfN9fvWF",
-	"VkPnRRP7UKI9j76YT/7y/Aun8tS0GtXVd1Ce964VeNxXZ3krR51Lme0RCjI89LHvds5q93LwKEPnhSX+",
-	"CTy3ljob0eG0xn3ut7EdtgWSLTh0ZYQgi67Osj1/bszY+e4fG3cu3wc7uO+TIH9Ah6O2nmJ2oHFhG1a9",
-	"Oyxi4/328kPTpPeY3rGIuPAwFVhk1sMtwDk7cEoWQ+IdgcOMMNod/BPd3ge9O7ySj4fcUIO33Xi0ABqz",
-	"LrK2Qlu3M3buordbb3FRukV6kYOIi83lTn1kPip0o96UrKmBs0O1LasHYjqQA5i5Dd8qgAls1a64FVeX",
-	"284VFDPsFkhiwPKtXX8Rd4spxep6HGi5Iz5s0V+3wZcKSOFd2xHS6GAEB+yKP5o21RZNEBEII+cgJoRi",
-	"LqX4QCjWVuiVY/w7Z3nm2QufXONj393wV/PEIBJrGDbHYbMEz2GU494VAhcQdEewEmgP+uqPW2BvBZ7Q",
-	"fu0IdX/EPL7EHHrprFUM930veOjKp6AY0k15tXd1FYBSh7XT2rHaFrs5Dhfb5TmW2uh3hclVILrjWw10",
-	"Dz6771ugdB2wlu3bEWIfHb+JYw7CY7PG5YeVM5omeBZDxiHC0msUqjPXdwmeHZbN9euinHpHTnEU+N2I",
-	"7BuShBp2XCxpZQEWIDtNC20U+7U5cZRb7jne+vh3RR41KLojbx14D4EUDbagkAZsvj08rM6yAxqxbgce",
-	"5l+Yp1ohtv2tMUtriZRIo3116fizbX497viQ5Dq6B6XrllW90VapN1EEmdf2a599zvvbDuvuOtUtr4zZ",
-	"tuEh6x/OMi8riOYQXYg8DXwkSczNQ0332IqYZz6T91i7jfo5I1ydp/jKby01Xwlt+Soxn4H0N7B4c44j",
-	"J1V0XwmtBEitmop4NAchufW6bMOtj5WmWlThLra8OyxB+SZLcAQpUHmesYREy7Xvtq79sWmuDdLMb4DJ",
-	"OJyvbqCnGWHcvr6tnoALgnE3JDExJMc1/Gw365gBSmawgv7aIbffhq6YhMIWIeOCtP4t2jSrgMkylrDZ",
-	"2iP55Npdj0e5idzu8UbRYBSK0it0XaFiQ5pj675dUF2FxOr0tEI8XoQYV0MtqkQxdkK1w3cPrlZwp4oo",
-	"7kDLra9sZm2PVnih5afFIRq2uG8PpfJ1j6TuIcbQ1mhG5Dyf7EcsPWAZULGIDlj68iBiHA7cQHq7HbPd",
-	"QqAphvPcxdXRNxVnintwiyfhKiA9hI0q+D6Bxn7fRp6pAdayhd2kGTOnHaVtI37G2aY8rHrg4fHtwTYM",
-	"hL0fKxrrK98i1EitCyyFrIbUVpEEVnrPEjbByTlcZaG3k1qLc6b1a7F+rPP+zHA8IuJ8js+Twu98VQ4h",
-	"Yt3njIOO/I39LXS4Vtt6qw02WkSdx56bqJieY5S8uJRF22TPj9X2xrbXGEKcx/atfnVPKkLNyqHuTAKo",
-	"SPWrIkBN6O4oZBvtwE9exo95k9Pb+g6vU1QLVYRIq4rkDZJooG8YWT0YFMKI2u67PfXsYCtiNyivLg/U",
-	"BikFioIvdZUDHAbtVhAI+TBq98fuLoxRSBHTYQDbXj3lPCu0M+XsD6B92WyNSzYzK9UfK1xTRIRJb0Cm",
-	"JtmMTbcwx0KHJ0wAKLJnjeJcB6HhM1o6icTskiqQUMQWwE0cBEYpVtI61YEOGXDC4v0zqgPWdG6Ela8I",
-	"aCzG1XwPYs7yJEYTQDm1rljjM4ppjArQL0mSqAYCpAJLr9ME8npuCCzkuc5/1ZdpVyLsuyGN2gec9OiQ",
-	"cbYgiljNwa3x8S2a7pKPt6AizylVe9H5zd+01z67Pi0vwgn49dLtNS1N3ZZsHZFWiWkVDyoHXJ7cCuOr",
-	"nlCdDbrdcQvbSBeyu78bFmjjD/2qkAv+1IhWhQVTfTrF93PsV9ptONjOnHh0KFiH1/aGE48DowGxG88n",
-	"Ulf2pbtiU91MDzLbz1toTjWoPIpTdYbtrcA/NUYXi0jtGdNEM9VYDOqXXKgLmQrzW6T+/Bqwk9ofKU4J",
-	"ne3/ZCDYEI/NIC4z2ltGJWfJ9yz2+OMlsICkds2NiOI442JtMUzymX4U0T9fYq7dFnXkxXg0xVKTfIap",
-	"jg+gSmpau8Fm1jVkXYI+cine2twFbIMNnQU+gLxk3OMIphfa06Q55RBgzWHHvXL+zg56LR5duYAu7pt1",
-	"z2YHg+qOZ3rj1ELsaC2ufnbzjo49xJut9ZU7bqy/9THLzeTOq41dBi3LfL0qdeJ5qdAJjSwHdWnrjPuH",
-	"BaZ1b/oxzHJLPfhVfNyCYTbg8rDM+izbG5tWzq6HW2sLdWziw9/lwDY5rpbD2sFRrTmoXR2TJadNXjdV",
-	"394vm/qBuu+rpurU9qKpvt/D18zKBq3eNIFXxIqWdz7jOIJzo+vVhfsyyfHqAISea5H+PIU08JhYNBGX",
-	"OAs9d+F42XduDv9hhG4Gt8gSIsPPc82QOv34E9ys5jasrLmxQD/oDaDWSDDqrtj6gUZfOC7xqz+C0ySL",
-	"9uTU079r08QcCplIJ8Kp5JfuxIJYDO9Vl3WvyavZaHWkvwWhGvWvwbicAwebNFvDqg0TOjkq5jpDJ6Ez",
-	"nfvRm8oh8ydbNQP4li0ZEpJxPAOkwUcCUzNf5604ffNB5771ZZKoybjmUGqviAbeLlhTHPaO8GbjBz19",
-	"HfguHTfqXcV1OgB63KMOZN8tXSB4UCpZTedcoJjqqJHbi6WFbl4fQf9cH6KZXKtdmAnr6Ho1WwgcxdYG",
-	"Dn6Hokavp0GfNSM4cOjJr++r3iYPJTf/kHa7j2BP9A3qLh+Uuts/9YWx9ftP7b4IvvvMbHqNlWPBGfH/",
-	"XuTD2Ni4vpJSwyfwq35Y+rF3g1egmXEJCIHrsausf3xnC+AJw3Hw9b0Q4xqra5rn9SGYLa9vcLENdWP9",
-	"TPtINR5OK9AUU3dBtG2N7DU8E06g7X4v+d5DAgKU2JEEZQqQHGLfTdXzJfRGXULNmftjVl2mtc7+VTjb",
-	"zhm0//PdDvw9iyGKm6fTCDr12xqH0TZP0M1fHm/Wv3MzP83zAlnOTVmcDq+M3R4Uu7hmWiSuomzT/bJ8",
-	"X/T5XTZwoOaJWX+AdL6YNQ/MldW3X8UFe9hcxaqwF4+8XRl9U1XLDLGNslUC0V2LqADuwWLzdQslpQpS",
-	"cNt2pKhUNnAF2J7OiuHhi8ox3VnBxzp3Lt/waPUFb461FcKImVx60aimHvxvDrnPYOrTOfqYTVd0kOYW",
-	"Ncf3bdYxji7wzGOixjyah+++JIF4VQDEfgGw8ULl+r9pCkSq8/4nNULb254w1t6uLxfj0QK46GTzdIYA",
-	"235s9qB45qgu3IDRsqGb8y93Ih4qrI59VwFsFRi6c5cq4B7Cs5+3YF81qMI7tyOHhWMsDXE0IA1TRqEa",
-	"bUIJutBaIPOJuX874LYZpNKljtDBZQZzD5UvCW6TcRxrX0tMZyZjScoW5n8aEf3lArZOYDR2/+dlCayD",
-	"MFWEp4SyDlS3oQ9GVjbPi/Mymm/DJRQK+jFdzu+YQ9iV9dysMHeQ0Xwr3lDA490vN/oO+EJDh2oIEdpg",
-	"5a8x5zqiQvB28Om6ikbSGI8ShmOEFzP7DiIQ48YCYQcXStPWz2ocsJbJ52TqF1Ea2lqw+l0BmZP/y2Sm",
-	"kqTaW4kyulf514HCjpzGMPVPbJXCxou4y8rYPNm1Uts2LkUdlL652she+RH7aJTrPI46jLFgSZ5CWLds",
-	"dd2YGzSp7X5jyM5+S+pge5I9Y94nUPX7NgRfAOKjdzf29nqMGuqfeqvaI6G64yUR54xnc0xDwTOh4N6Q",
-	"oaUzLq4klWRJ6ZdVCQ0tIVyDCWZj+uOD3dAAVpivW+JGFbQAhlTm2QWeCOkMgceczfxJQYg41yUVcdLl",
-	"0WhD/5rwI1LY88b1CS1NyQtlRlGXEn9VXiwyrm6whDJdq1nFZllK6yC0GGjUsowZwXg9nYC5gVcWNXXF",
-	"mTyZe9eOenpJvHpEDEISitcnIkgJtQT2fI37RHXI0IJ1gcufTYFQXzamorbsmjfLWgVZ1y14W6ZiFnTb",
-	"75YzrFb1tjafGb0ylnfpNkG95xikfYxoVp+Z5ymme0rE0oXK4CpLsNlcV3klQpKZyCUWRTnX9cCsq84Z",
-	"zcyMtaCg+ltuHqjz8eOnT8cuFCliMaC//nLy7u3/vHj5/NcxOrWFP77+Es2AAtfBUZOlmZNxMiPUFaqd",
-	"Mh6ADvmAq0osRCbg2xMxZ1yOm1sj8jTFfNkYHKlx9xE6kuj0x4+f3x+e0Q8fPyGjOZratBXAJAuDOUZw",
-	"FUEmz6haUpbzjAkQpgJ8hBPyhzmVv8L+bH+MckHoTHVVSt8CkC1wcEYpzJgkuu3/iwQA8mzry/1XX3qP",
-	"bIXUpDHPC/e0Z/YsgHsK4ZYBR/mecqepIeuVM9yptUe6PK+StPrhhdJbnOVA/fCyJTu5C2JwqWxdSVsz",
-	"eZuDjduGLdRht5GV+/xO/KiqS+khlVQ3wCf62O/bCD41wHxiT3WOHejC9Ue8ZhlgW0StrK7GUVE5ufKs",
-	"tKJ16nBK7W56pbURo21KnvvtSzbVb6+ExDOX6XLjVMUd0kOvzzDcni248CiwaYMN0L6DuH/X+jmOY973",
-	"0h/bQt5ebXkTx6dKafV2VHcFxEvQx31kjkZQejFv8KzMG76fF97gcZ0nEPCUuJEzE81yGff4OPXWdDjS",
-	"1pJBjbPtk668jhSe+6HSZIsrYgVCzy3RnGl77dgFe28aJbOa9qtjpIwnW0i3aJlmePp1y6pC4SlEnNuK",
-	"y3HQw82uo6WFujzjydL/nZdKqzfbmvp4HjsC7RBDslqNplhCA94acCUkzWm7RqI3NnM3Eelu0CM6ZX5m",
-	"ewHLnUWU80Bhrg0jzU2kpAKwTa5uLrEPK2hsjpfplG224jpNIL1spzHX7vjO5kpHwbnaAN7mJa7gUFso",
-	"JFVANjiUNWe/i3Nfd+Y7Pu/3bNYbxvds9gOVfNm6Fa5NOCuABwkKsbxLiH/ZoW2Bu0oPt3Fkt49ZtQIc",
-	"ii2p3GA9LnJnrF0V/JoOW91und3mggoA64lCFLKXBMwhxYTWXSFCymTZdlxM1HZChTIfimRINVSdYe3m",
-	"T1z17W0+T1izgJm3DfQQxFZ0WbVNzAmVJoqsMEiQGWUcBMJJYgwSSHJMhY5lQMaBRHjzOxUJuepTEBqT",
-	"CEtQ02DZmEugOaZxUthuTXFvkSfanqujFYTNOWXgipEdY77MgC+IYBxpfhFIOkVskEAdpgtY7pkYugwT",
-	"LowRJiZ0hhQScf1+oP7fHLAtMB2xJIFInqm9gL1LEgPCE5ZLY1x2a6rCUR5Q4uIDPdFcsx6MuSHx11cl",
-	"IUnMYca6OBsiU0SkS+MlOZnNgCOM7AD2MJHLCXZGq+dCmUR5FtjVakauxmmXO+Fs93g24zDTB0qoZOij",
-	"ccHW5jDAMWJT9GaBSVLax0zH/TOqi/QKRChyM5ajm9ruQrIM4RCiBsDv4XMfYgrrVI6KsrKSc8bujjkW",
-	"nFzipdBJ1rIxggVQhKdSn5NeW7+V9S0QLIoy8w1UatZZ1+3qmK7T5QhBZhRipOvAr5ri8ayns0q3lByO",
-	"n5UJxmyKIUNnhqpKSqllGFtJJGa1tVKDK94yijL7eh2hcg71G9XtztbBTrwQuBWDZ4Z7l96HJv5hkuDo",
-	"IiFCuh9m+j1a+7qY7ICj8eg/TH9KAGsPRXUxYLMtNryB/GG8JRnTG/F7jqUE7rcxV1LLrb5697jBA0Ui",
-	"w8pjWxzpypVvXvKrz/qZ/m/g6neB+R4vVyIJ7mBfsSMcFe019rt4qw49P5nGK5J+MWAxXssCjqrgNq9h",
-	"+8mFjc+ZkEioW8wlMkBA44wRKvcNmXQOZMfokvEk1ldiTsnv+l6tjIdIDFSSKQG+X6swSn6n+y+ePXu1",
-	"9/yZIoL9fJJTmb9+9vw1fD2JX+GXk6++ejUah/3fG1xrmRVR8cXc+vm1PquIBOkaKR8s4dLc8s1Vax/u",
-	"NPVD72x35fTqA6a7LuxdiucqaLbbQv32A9xhm3f0PuiG3WSfWrZmBzuyZiN2u/5PBUNs0K3+3VFuI8vK",
-	"veBQ3+49f645lL2m9wVfvI5h8YI+37fw7ptV7D/vz6/wLXGsaA5xnkBbeIMv26hfb1GaNM/7hcYXnaYk",
-	"4KJhksPmUQRChFtRuOo/ud2qwNOd/nZudTzGQ68MpllDgfDI4ZWt7hiSUXRxpu7qDje3zrdR9W0p1+tb",
-	"nX8pbUizxfXmFnZTluNd1PWoLrMHF61ujo9P2+/bMOoaYD5OXZ1je8txaUJyE+RKv4rZJS1TuFbDHpS+",
-	"FE+WSDcz/6sb+07TVAMKPRNmmOMkgSTgYlovTWmbds7vXJ15N8bNemmjzudZBcSDMp8qcfdlPM0Uk4SZ",
-	"epveyJVKGHrpPFR0mSZw5T2Pz8JXfflWy9wqEI705evzDMR50G8JmwiQUJqVviaHCkjhXKI4BZHhgN8h",
-	"x5fnBVidbuqyh1tQdY7gbm3MifVxe1hIMepdKRQOgO5ssQDZc6Dq2xYctwQmsFU7EYq1RSPKOZFLxcFT",
-	"A+AECxK9sUivAdJcUP1aijRzKXWClQlgDty1Nv9650Shf/zrkxUqzBD6a3OM64qF3LrNjizTM8Z3ZBIF",
-	"FVHlo5f7z7/ef2ZswEB15qbRy/1n+89GlZSKBzgjB4p0D9zgXrFf59xWkq9qqjiACVdAKcg5iwUSeaZ4",
-	"c/k4YBy6jV+ysWIRRo/i0evR30GqfbBJe1xebw3Mi2fPrH+NtAmocJYldq6D/wgj95rDX5tOys2hd66+",
-	"mo8/GecYbfL8xXCuX9Uv5W5IdmHczjLmS0f+lgOWoPNYcpA5pwijf5x+/ID+BRP0SfXVuxAlRJ1MhCnK",
-	"BSCs9AcFGOPWA1zXBomBI0IRkQJNWZKwS0JniJt4FbF/Rs/oJ/0So3+AGHGWgMmcCekE4hhiM/IXmjF9",
-	"gaIEkxSRKUqxjOZqMAVLLvgZdU1sRQDf+RwzoQ9Ir8JUq8EpSOBqr/x7XjY5OFGwja7HzQ1L8RXSe4qc",
-	"H88YpfiKpHlq8iGiF6/m2jg8ej36PQedv93eYBXPn/LsS43r+bPUp2/57OQGApGbm1jv0xiluZBoog4T",
-	"wRUx70nW106dGg9AZUcJADVlrCtQOj+N3YRcaAM9igx+lTDrczMQh+BxJQc90FDhUXWvf71h8jMYFKC/",
-	"8eiVmc43SgHWgWqk2z7v0va5afuyS9uXpu2rLm1fqbZfdYH3KwPvV11gUI2ql4umr8q18suvCmGqV8cv",
-	"v6pDa+Nbl3OGU1Lh417m+685e5Me3ST7rcmKLSjQ9Vh3t02WtA+MNn+AJ06n8DL6N+qzeQk3zymONdhX",
-	"ZfMuW0tpozn2CZhHOJsB2b3jmiyUyCSXtDTPqH7A14HzIYZsvaZtrnMN8g0eni9N0KMh41fPvunS9hvT",
-	"9tsubb/txx62wGWLfGF0nnIAE8nhx+d3+rtGOCOgmHvOId8ZPeaw0NJkkiAbDuOwV6AYIm2AEmMdqmcv",
-	"GNdOIIkvgBm574zq3IyVymQm5RuawJRxddsua5XNCpxX9KCvxaWQkI7PaAXOSyX06BhBQCmmeKZEnxLN",
-	"u5GP2YKBfmr085hpIqfrqOKzbdFCFycgpMLbIE0o5Nf3g8tZsdyESBSsVTJJAC+cBG9SqziXkxDxGIKx",
-	"1IN6EM8YCYZyiqUEqnQKZ5VCRJxRoNqhHuEZJrQTmbk9HQjt8RNaGRETkjotahRW3X5aJVGHy5c/2Op1",
-	"Wr/s1uUozYALRvv1snXkxOhGdaRqtbp7jbW3jF3aPGUSUNR35BASkIqTRpZh5VRJ2ZjGuqqpNWpoJ0TF",
-	"5KzB3SCntSGgKUn0i22De6kJd4KjBkbRA9k+q0X06XCqm98kZr5laUqkvO/c9F5wvQP39O01nJ4Y62BV",
-	"pqjhY8BCWkPFd+bJuMdps0iC3BOSA07rp762SKL3vE1CLjDpzK72EizkXspiMiUQ7/Fp9PLly28ppiz4",
-	"wp9pN0U12v+dncV/vrreU39euD+fzJ/XtT9/PTvbV//3fPzt9Zd/+/ff/ssP7NNkkLnnmj3OA3ijDceu",
-	"Mugtocz1CsJ2UNFfOBX9oZkUHoykph2Mw9YBxk1YBcWJfrFgNFlqPeVNHCOMKFwWFbaqLM26npdPFDgj",
-	"uuHK6wUvzO3aog2x7vgFZ0x+oZSTLxSAX5gnjqJzxlkEQifJsTOpVm5M49y+pNGcM8ryspvOSuQ2VbUS",
-	"QGURQ1Efwxg95liYGu5ZPkmImEO8r4Yiwn4nwpRwgliv7ruz/NmzlxHOyLn6p/6XXTKzTzkuKVAL/GO9",
-	"0+rX8vXHTDclibr3x2d0D/2DEXpqfIjGwbnHOI4htp/Kn9FftfroDq9YpW6tnxuq6u6XbrojE8bTMp1a",
-	"xl7lc3DKSywQTnTpPYRr0xWz6QCSDefCFOksPyYhE4pzxZhsIf7abLpO3Jft6us/jA9+Q/pbTXrlCAHH",
-	"q3sYeKOxEYjl27PkOQSebODy3DZPCX0PdKbI/EXnV5xBZjNhEVd7jqGZ3V7hiCbWIsgST2BGhLG46JYF",
-	"x5AMmUzSDYRGKaQTbd3pxffeq8HXM746DBtyvvogt8z6apN34316b9YzP3McPvZXZ3u2nZ/x6bnWcz69",
-	"ihA70tPZwDwPt9NTrGN3rRPslN+9t8FGaxmes0VWJ9gBo2Mx7F1KtlfkZb8DfncjslYZ4edVDQ/zNCsM",
-	"ztUAVl1HR6cptGKWiRFtVxWLGLZ+VosPzoftowu762CHOAXjm1z2uVFjRG2BO3hLfhBGhsJ/tcWoelSp",
-	"ndTv2I+xnPc58Q8shts5bbemkFVUR5+46GNjShmXYdI0thHJT0rcKXBlFX0OMiznB38WrqrXB39eEBpf",
-	"m5+uD7Jq3ueeOuFnUfr7vT35WcvClDKbG7US3K4dB42nBNGShA7k1c9azEkIY0SmJmjZxbpjc4HaYPhy",
-	"qjA39Ca07m/HVcRR8MVudlnV5SdC4+6t1QSWkrqYZ/oRkXcjPMT01mS2NReQpSlHSzaaXUm500Q7rhtx",
-	"Tg+mhDmbYKJ60DGJ9Znp84V4f0UEuB6UlRbqbdFWutJzKXPcKDXbfBFWpC9wxyb8AKpTRWCXAWEdrW4o",
-	"uzwGSm1sgYdG1Tm6p6wi3cFAVRvciRTkJeMXbRLVB9NErFOHqkk3Sg1vgqMLhftuooBuZFNyFvhxm365",
-	"doHr3pwf8MG7zV859wOSdTj6o+PHfvZHx0/r9G2CuXXPs1buGRe5kGhs9QsUY4n1abe56SoUsqbfnir4",
-	"relWaiZ39k/pLtAoUMeIZriT/yxvOkipnOSRUqNn4xULPPjT5ay+7u2HbypuSGPebDree8XMY2h6zm8k",
-	"Z7IYKqLg4NH4CDwae+BnlADmLQGB6rMwVnmB/lpx/B1rR1qIv3RuabWAEK1lhxBXoZxBXD38TSHuOp+M",
-	"Z6OnflkEcCLmuO5N0cZ7DnXjgfcMvKc3nnUM6nHMZX/NLVgEwGyHip39VU/cG/gpiW9ewLU3fRRBNjiw",
-	"9kS0LBfzAyxsntGQQ8SUg5hbr2saF75gLmORMferQVBMRMQWwJf7a+6341zM3wiTwfOJY+UTwrSYiItt",
-	"EU2N0Q/PDtWsA5o9HTQrokm2wbMMRxd4Bv1QzVTDH3DtCeHaxexuMO1iNuDZ08AzEWF6UKuMvxbhCrND",
-	"tRuKcDSH/TP6tohYRmpsCtxkFzKlFspX4UjH7ZtcU1T/Cgo9K3n+OTFxzXpEbKdRQ7m8NiaMGDGObF54",
-	"NAUscw4CTbBqY9+XnZHPoj2d2YDmrvaS0wiXyyIgBtp4IrSxFByyVkvyW8NsSyZswlqKnuu47Wkxxa3h",
-	"1DvGo0Hhfoz42iM1RVfrTiXvwmDfGdDNoFtTXFgbq1yVE6yXl43nexTSgn3g3amIcKM+8MWmD9kiuiP9",
-	"2qwkGgc2TfewIbcsc4uMbyvvyZDE5JbRclcZTIzO1jV/yV1g85Du5Mky1s6JT1axeB8dTZEbz0VK6uBQ",
-	"FmHjY6ddLMco1gEiV8u2S7ya7OI2r/Ahy8qj5uCBFCs3gXJDgpYnlqClC5c14TbOUlApYRqy9eoG1Ugd",
-	"rR5p7lrJxKKZq64aQGO0YGUtV6GYrWLEkYkKc8qTTUUALkxeq2iU6RJcOs6H5byWjdJEjgn9trFEl0R7",
-	"TcszKvlSv3jY/JdlRkwbv27rDatVhCy8h3phJ0Ul0MEf7lZQFR1YlOqHs2KeS11gKIi0p/Nc6hpERSB8",
-	"GD11MlNqSu3W4kDP6PEKctYQtJ4sNQNOWDyuI6jkyzPqRU4skGCMqr9yDoSX0W4uFs6u0gL0hTijLgGE",
-	"+rkdlU/dFvXF5UNXFKF7HNutWCrMso7JIEtvRzqSZS1k46GBjXj71pxd4br0UE1OJUlsquGi//mM4wjO",
-	"DQEq+oCrjHCI15CI2or7bJwbUH47lI+pOIjzNGvPlFLNN3f44RT9wajWKtX5BbRDczCHH07VAPcbhT6c",
-	"/ptReMQPuH2RQmeBaq1HBdTwOyvs6g6iDRF+0C1uwTbW525+T1IiuzTU0L/TWbE6N3+LozncVEYfCVfS",
-	"HJNXK21Ddw3cYDLemDjmE/el+pjcWUW0FDOfoN/UAL8pSfY3N8lv7bfxj4C5nACWu1LCuoqvxcSD7nYH",
-	"uLUGs053h1enA1Y9Iaxaq+XsCKd2oEIMKHW/UCrRMiDwXVyFbqwNkOy97Xrb96Gbd8CyO8OyPpfiDjDs",
-	"dMCvp4ZfXa/HnWDXLd6RA3LdHXIlbHag1HjOkvbcBXX8eM9mb22vO8SS3WfgK9elh/UYJE5BIrxCaQmb",
-	"oQQWkBjy6pSRb8DorTG6J/LuDmnvDP10IL1FPodzA8LdPMLxSXyAk4SZYw2aov9u6zyr9tanHaWEMo5o",
-	"nk60dzyNUca4rJRAMcOWHuzWQyPk4nZ48v3hmxKUe/2SUQd1J/bd++OSo3Bixa28kYwFZDRHU85ShM0D",
-	"BTa4serHi6Ycz9Lw+5U7+ltz6i0nux1EsQsbHgFKr0O/qG+DxTsjlGqs3/6TpC1Y9u6R62Zyn9fXZuPT",
-	"fGhm07ANGZV3xiDV/SfWXpbm4dY2DnE+/fl+X3YaxOEhszN+dExj36Xoya1pobeZYP6Gi6ocSUiHoiq9",
-	"lIViWw6QWESjsef3hdYuV3+PpjPv7wL84+SC74h+nAFxwliLffp7ZqNubHUBN/h+a7EGE3+t+j42Cuwc",
-	"kfYmSU4TvOgV9vYzFh09d7xR9d279Wrdexmn+USA7NHhE571ac1uhxEOSQS24na75VKxjiEN8ykbNLsh",
-	"pzK9nyyvur3kHANt3ZgkEZIYQhLG7iWJHimIN6DRW8xI/GTlid4zDJzjSd/KOp+PsC8ffqI/dk28dI/+",
-	"ZcL1sIRzRpMlKlAMEYF0QWBdfa6sR1dMCbENNSLCRizFXdhIAc/ASfqk8DC5lU5YkkxwdHGDeene6/QG",
-	"T1BpUrj8kSbLQdEaWPqdsvS1XrEzogPsMI0RBwF80agOKyJBUAw2yFO4sH0N/QUs11X6tHz65HZdGQcu",
-	"DYOlamCgAwPdBQNtc8k95CyzfBOb4tiGkSquyu0vc0iKHJmObTo3IC+b7c5Tb9GBd2CpA0sdWOrAUrdn",
-	"qbmYH7icwEVV1m3qZzTsEGXCYTU4T00Cwi4cNRfzE9vXFoIdnhDuG4UOVLcR1fXKJreBQf+2gyEHcWQQ",
-	"RwZxZBBHtmeMect7x0nufelAEouLTlwxH14m+hC4dt/maZ8evGtGxIFx3ijj7F7bgC7EwGefHJ/tlhpW",
-	"p1XdUATdOLPqU+a4A0McJMmBw+2Gw3VJDrMpbxuU60G5HljiwBIfIEtUPeLJcgPOiIh2J1S9URqshOnh",
-	"lKd2yoFhDgxzYJgDw3xIDFPmHeu7N5ml6duRR6pZhufNIc7hSdJYp0orG2lpg0PWYH0aJIeBq90BV1vS",
-	"6IDQGYgWG9SR/l46SC0w12mkBOIQAVmUxdzVqIuqf+qSRijPYizNt24eVadLGpk5B2HjRjnQRgxl4BFP",
-	"jEfkdF1U92fbYlMJyPUfpKAhsnug+/tD9x1iuz+Xje5JdHcFooGfDFHaNxJ0PahuA3u+M/YcJYB5mCO/",
-	"VZ8Rpgg4Zxz99WxkXPSnmCQQn43QlHEEVzjNEvgSkUZEocvm6Cr/tjJcPdUTSbA54PlDTXJpEpUeTEkC",
-	"wYTDJyBzXpNgvFmzWYrc/PvoaFr8Q4ko1GbJTFiEE/1ljGKmxJmrZSBxe0FHeq53CsAnna2WRRL8VWJN",
-	"RN7o9WhCKObL0XgklxmMXo+E5ISGUsOPR3MtpOipr/YSLOReymJdt3yPT6OXL19+SzFltRliLGFPktSc",
-	"hVRS6ej16P/OzuI/X13vqT8v3J9P5s/r2p+/np3tq/97Pv72+su//ftv/+UHduAdD4F3JCxcweFUpz2h",
-	"cIkSNhPtFP6ezZ7gy+l7NuteiVo1ZknCLjs2fk8oiBsuQK2nGbK2P3QqXokbXycD1GLBkcSTBBCbeg0c",
-	"7XT/mAPDb1LjrO7bQIF3p2uq84jzboKza7sNvZy6+QZa6Uwrbs/uP528evaqS9tXj5ymJJZQqKPOiFPT",
-	"VDgkWJIF7KmhtAzTUCDarDLaovlolckulaB2rUeulnl61aVq4quHSHevnn3bpe23D5NGt9XnFG3cki53",
-	"G8rT+rYK6nugZT3yeleZ4j0hvMTiwmQAlAyphggnCYqSXGdgVR9ES13IYzXy7mujPSz+d2/OeXtxek0F",
-	"2J3Jz4PAer8QR8wP5kzIC1iKTsgj5ijLJwmJkOqGVD8kTBq8DICjCFMkeS70m0WKCEVECnRB2SU9Vz2E",
-	"fvJow7TTH390AN08sunbJUswaaBZR+ltwKUGLl3AsicaXcASxTAl1Hj7aj4kxFz97McrIh1W4VzOGSd/",
-	"QHyu8XA9Zv0EywGpHhxS6XPXOm3uQatPjts0sEqoq03jTlCWOc4dYuhB7lieeewnuRQS0oOYiIsgi/gn",
-	"gUtTzV61CtGxHujQtLjHxXmJuBgkkb7oMeMsz9bjh2nWiiB/t03uL4ZoCAcU6Ysic8zjS8xhPZa4lqId",
-	"U350A95nZHFADvjSF19IhuOYgxA7YStHx2/saPcZWwooB3Tpiy4Zji7wrAN3cQ1b0eW4aHR/kcXCOKBK",
-	"f1SR0bwLoqhma9DENLnPSCKj+YAivVGEq1OXyw5Y4lq2I0rZ6h7jigVyQJe+6CIwPSCUSIIl4+txpmza",
-	"ijSnbz4cVVreYwv+mw9qsgLYAYE2QSDn3NGOOxLzGUixFnPUgTwEpBlwpS+u5AI68BjVag2WfFYD3WcU",
-	"UQAO+OHDD+NGGcQCtWnaL8C0Ey6uz7oJBF5bPprGvVFCIcRHPTVObhYhDIQDSmiUsDjQRIr2e6Tympco",
-	"JGFT55KrugmUKn3B1ecVYAukwVXGQeio/hlZAHUJflSfMoS/Fa2M59AmqHUbKGX9mh6lx1EbntT8UsUi",
-	"ck6pscnj2lKz1DTQWHA5ZwkgsYgQ40iwVHunECmKuIlAPsnTRWSH2fQW6u9o2jfx0p1kUBrcqQJIbL09",
-	"e6Ey0HZM/oHuApHNKAMeD3i8UzyuhQpULvXAJXt7+Hffol7M+o8kpI/6Fi/c3Yt/mvjK4p8mrLJsDLXG",
-	"9SDKTkjn0j/hCasXJlllg+YMbFYY3fzpoiOP5uCqt/9vDvl9z4/TLybkmy5tv7mX8SN3TUcxJCChOyEd",
-	"mvYDJQ2UNFBSjZJW05C2U9K7rZKKDpQ0UNJdUNKGxDEjC9AVeDqTx99dj4FABgK5zwSyIUV4s9e2k8Tx",
-	"tpljB5oYaOIBXRpZzmfQLblzYRFFmMbIKDWVBC/7Z/SQiAv9cVqxn6I5S2IUY4n30fdwiTmMUSWxNMpF",
-	"jpNkaQcUJqhEtT6jxzmf6XBnbaCNGZgcixpm3W7ByvfOXJRVKMQiCmUurRG7XvxA6AOhP35C57BSZ7id",
-	"OE5sh/tPHl0SwvR0iwzshaYONSHhEI9eS57D9UCgg3S6EUX2pMfTB0KNAy0MtLABLdRrK64jhc3rJQ6U",
-	"MFDCvaaES2JDlTrSgmk/SGnFVgxC2kCOOyPH9aXv3iQJu0Q4lyzFkkS6ygpbAEdsqs0Wl0TO0W+swBL4",
-	"bo5/2z+jpp+cA/o9ZzxP0YJJ0KVZ5FwXk9BpvspWri6LAQxdzoGi3+yP3ykk/61qoeGAYphxHEOsLTKU",
-	"6fKdSobEkwS6WEe2rck33LQDaT8gA0nvYnd1e+gFQBasHnMDttEKJB4Tad4oyreloXQHFfUGbjBwg4fA",
-	"DQzdrve7NRWb7jc1dHbm/mGBkxzLPl2O0gy4YLRfr59gecl4LG6WUu0sQ9DYrp22dD0so502YoPMa6AA",
-	"fV0IdYsJkPq+U38v7LG7oMRghTVPsIWa8BGSnNmxPiVEP6st7VVzVDe/SUJ7y9KUyKES6J36Ru62uiGm",
-	"JrWr0VsxiiFL2BLiSkHn94xdWEUVfONYmbMsg4imhAup6yU2PsyxklfLFP61kjFrqydW2cI25S6GSohD",
-	"JcQHeBWvsQ8/KLoYiro8saIuuyWF3EcJ+UAIAyE8JULoJzfGWOJ1AiNGQvI8kjmHuMgecgFLrdktcJKD",
-	"cHbFVhntUM31OBS3n2CpQbrhnORY4p9gqROUPEkJaStzxBskCJ0lsCc5psK+mEUsVVxR/z+bIhzHYxTN",
-	"MZ0BYtz5Mxf4K5wacwHLPY3pSEjG9b/9JQpKQ8X9x/abepFXe1BF3fUP8Q/tpnkMZvKbuUtcSZky3Nlr",
-	"I8T6/tC2Bg95+SjLdCxJa4vaMPfzLhkSqdzE3bBGrtEXhMZFg35YuMLfGlw0YfFyrUzzJFDxxsxUD0t9",
-	"uL9CkNdV4S0HrNkthUuN5oR2ZbilDekx4/gtaNqPS/i5l7jvKzT21kj12vFFY7oS9ymCKyIkobO+1JAP",
-	"xDAQw/0nhs0kdtGeUdjSiOhBL00BSTxdlzG7A84R5QGaSx86mjtXywNCp6zL87jrgFSHsvJymVm7eKxu",
-	"t3ie2HGO1LxPlgCquzC4Y+3cWXG7auIKpyseId3wetv64g8fpx9O8fL7y+jbcT8DijPS5oN7eolnM13K",
-	"YqtjtlKqTZd+v7PIuj00dZMr25UxlrTt1TFjiUcGqy9U8QHFUzRfQBMcXQCNtYyHZ4D0FOMRUS1/V8rD",
-	"aDxSrUevzZ9xS+3sGy1fxViyjgwf8FWht71+0AcLluQprDvvf+pWj/jUzQKfztlzSPDyIAUh6hUvV07/",
-	"RDX82bbre0frzh9s9aEud67u8NaUmDk67NzjswBOb0H4rGzF48QSjRZrvAEbGHFTkdjrdlsBiLBx+42x",
-	"xAKk9ThGehVoDpjLCWA56hi+vc5W9OxJ6RUOFeocQ0gs87CN5+8gkWUqwqkEumM9TNBAGRM6c3HJn7Qf",
-	"94zQgwwLccl4bDpIhqYgo7lWn3lqvC0wN8ZYoa4aXe7bHbWeJqBvaIQ6NfBvxMhEZ350AimTt8GNzHIe",
-	"8bW1ioXGANB+Zdlw2C3LkK0/bHW19Wl/QuLbqXLmtiCEGTOQpWXKhFyMy4wAWmbTdPK0GJ5FrV+vr6+v",
-	"//8AAAD//4T+4m7OMgIA",
+	"H4sIAAAAAAAC/+x9e3MbN7LvV0FxT5WTcynJr+QkvpXacqx4o41jayV7t+5GOQo40ySxmgEmAIYSk9J3",
+	"v4XXvAgMZ0jqYWn+iWIOHg3g141Go7vx5yhiacYoUClGr/4cZZjjFCRw/a/Dk+8P3zA6JbP3OAX1Swwi",
+	"4iSThNHRq5GcA5rmSYIyLOeITZH+gSSAiEAxxHkEMZpyluoPVLUxHhFV8/cc+HI0HunfXo3sJw6/54RD",
+	"PHoleQ7jkYjmkGLVr1xmqpyQnNDZ6Pp6PDrMOTZkNKlK8RWK3Vd/f5XPZR9whdMsUZ+/EqOxp8sfFkDl",
+	"GxzNPVMhJOZSDxNUKTQFiFEuCJ3pHxMsQUiUYSFNAVHOS6RaRHKOJUqxjOb6R5FBRKYEYnRBaIwwjVGC",
+	"J5CI/cCQdCu18cQwxXkiR6+mOBFQDGjCWAKYliN6SxIJfHVICRFSLaodkCnl77z4WPZOJKRitVFTEsFV",
+	"xkEIwugr9Isa4a+/jPX4vlvgJIdf//uX/RhLfHV1ZX84U2tVrtCHyX8gkqcSy1x8ymIsIR4rEH43ZWx1",
+	"7YofMOd4qUf+jqRE+sacEok07ShiOZWBAetyfvQ8G4+mjKdYjl6NCJVfvyzpIVTCDLghgM3WTXzCZrua",
+	"dow8E1+Z8Prs7+/v12ZbkPi7b/E38PQlfL03iZ4933v5Ar7e++ZF/GxvCs+exl+9+PoF4P/pNvNs9pYl",
+	"Cbv0gEP/bhiGzURo1Ka2RzxUof2Ozd4RCp654JAxzatEIJqnE+BqsjVrJvo/bIaASk5ABFef6m8rBFQX",
+	"WIlMkeEIPuiOcbJKCXVFWsSi+94mC9+zuK0XFgMSkEAkWRUAIUmiygcEI30+xn98B/kzr3w8xnK+2j3T",
+	"rNqHAMXIrbtBSVA8eTa+hMl/B+kJT8vGdG1EhwizuSVEtS6QZEiAEvZsJtCU8RZSRBfGrzReZ+lF9GyM",
+	"xCJ63olpTyDByzdJLiTwo0O/JhCZz4jEqFAqnFIgEibVB0b1P7lqLrSRmWbOSdxHIxiPrvZmbM+2UVLq",
+	"aFcsQoNKDLVftyLcNdJTkdHknUDKpIe4oynSLaBCaAESetdTBGpqhPkR+ELNvUBRQgz9++hoivTejxhH",
+	"lCmsy0BLlSYgnUAcQ2xaD/ECNwSvEcJ6bJ8EcP/U29Fp7cbM7u85aAzNsRkWZ0yiGcdUE45NsRSEwDMo",
+	"NahSWcoFcEM4yjCXRHWECBVS1bXjLHp5IspCoXHmjvgOi9jC426lGCI0SvIYEHGAEhmjApBSdwTI4HQb",
+	"3Hn4fQ3z1hnD0qkoJnFYNnIQLOdRr23D1QlIyKn4y7MxybwC8oQl0DJ5OCOIsyS0S9pPnqn5Lw7T0avR",
+	"Xw7KQ86BKSYOVJ9eUXdqhxyeHTcpAXoqn9sgQ6jaF34EzOUEsHQnLN2iFdddT0dt4zzEkDJa76bs/idC",
+	"40CvSivfuFfdbtnNOyIkUOA3O8haL2Xn23QaWrZCuWtp2GluXfQYdTr0sobtjsXQNowuO08dwx8rG7ZW",
+	"ECWzcrMiIpFk++i389+0gP4tYRFO5kzI3xCHKXAkszPqdk9zfuUQAVlATZrvN45uRTOB8f5DcdPrJDlN",
+	"8MJIBS+Tma/hAb6OpNq0cZIgoBHO9C6AaQRirIcTM/pEImxKKXIVSUUhRKZ6x8TiAmKlhykBmJCISEj0",
+	"nujZ7Czp2mDC0xDhkf28Zud0jXFj4fC2xBsGjHAzh5CADE9mrD93USc/WjuOFstIQKQ3WMmQaWKMLomc",
+	"s1yiCcfRBUhRP0hKLC7+ktNLTCXEnRRPNwAi8CSBE5YkExxdBAdiip1zV67b9PxAF8G5AbroMjGvKQK6",
+	"IJzRVGlfC8yJosTo89Lt9mr8SsdMMY0FgiuIcj2BEaMSrmR9sn7+f/98ffJdulzgpM9U/aDO8FhCcEDu",
+	"e5h3DkEzONAIxkhELDMqWsToAqzqeAHLS8ZjxPEl0kaDdqZ4y3gUpGjKeAQdl+oozYALRlsGSCpF2gWg",
+	"FlwazkoxK6uhyzlQZCeK0BnCbrz76BSk/qlW3ILeTe13WqvlIHNOBcLoexyjEytSgXPG99tk30+wrMn6",
+	"vrbSBjCNZikZ14vmrLDrehdrul/PEJ36bddWDSE12tQiBGm7uOxGmQOv3vNStoA64wFd7G8ipN4Bjo09",
+	"z2s0Ml+7wfxnLGS4qdR8Xbv5rW5rlaMeUcy9shPW98ottsETd8o6JXFoHMVJ7Fzo0345nMKCmudkdQ2a",
+	"ZxrXkzmgqFN/hY6W7hudtnZSb/UUZFg1AdkPhiwDcx3hTlkQIyzQWf706Yvo4lL/hV/MPwmN4cr88qv5",
+	"hWXmn+ZfWhabH8xmjFiGEnIB6Dv0f75De9+tQh2w/G7KcyJFH7B3UM86zUKJ1IaaVjnVT5YaxqrtXSpv",
+	"HQYpsYQPNFkGx6kKnDNVohtjn+YThY9Qc+bruhOIbukjnoWakXjWsQ0WbIJ1a+ETFS2skNOOzFDVK42A",
+	"KjRLI6F3rVleqx3UmF40Oc+fPlV/tCJG9frgTGFG8+XBf4RRw7udRo85mySQml7q4/zwk6Ll+dOXq1Pw",
+	"nqE3tvfr8ejl7dBT0UxMr89uo9dPFOdyzjj5A2LT7Yvb6PYt4xMSx0BNny9vo8/3TKK3LKd2nN/cRp9O",
+	"1fxIUmC5Xdhvb6NndfZNSKS7/Op2EHxEJXCKE3RqzNc/KP3a9H8roDo1qhT6RPECk0Qd+rR8tFVVy6/5",
+	"hEiOJePmwlo7WnC160tipI8ofm+jwta+Ho9ynvilcnkq+EUXGrumfy0koLkRUq28zuX8iE7ZKj0pyDmz",
+	"erYT2EDzVDXLMqBacZpgQSKlJn319FvVkdG+Kj2FlXzbxkq/5u7i3HxaaYUIkRuluH3gtty40tyvzTJu",
+	"hKF5+cgugK4SCFeZauEcy5qWGmMJe5IETjiuqXaqK027Oj7i3uAMT0hC5HKVOnfL0t6RLtXe9JGEdLV5",
+	"daBbh9EKeddjY0OuYKfRgw8qKazv5D2L4WdVrjk0a7PWbYwNvesHKjrfGTTI9wC7LPGOCLk6hRt0I9on",
+	"Uvfz63jNmtuJMd17p8TYgksBtVqCpSmRSrtaHZU4j+aYziAOKL917iwK+wg5fH96AhHjXumAhf/KyyFz",
+	"5UOAI8YjKROf34YjqBMP2cJjS5hptAV2h+9P/80odMZBORUepB2efH/4OklYVHjBbS+pjNztc/Y2N+wp",
+	"oYz7pzNjXAYcZKrzqYu5hsZ1WUgCQCmcE8OSqhjKZCn9Vq8qEeGF89yhrejvxWdkzqn2bIKePNvnV0/0",
+	"MXReFLEXJdrz6Ml88pdnT9yRp3aqUVV9C+W571qhx311lrey1bmU2R6hIMNNH/t256y2LweXMrReWOKf",
+	"wLNrqbURHVZr3Gd/G9tmWyjZQkJXWgiK6Gov28vnRo+d9/6xcefyfbCN+z4J8gd0WGrrKWYbGhe2YVW7",
+	"wyA2nm+vPDRFerfpbYuIC49QgUVmPdwCkrODpGQxJN4WOMwIo93JP9HlfdS7xSvleMgNNbjbjUcLoDHr",
+	"omsr2LqZsX0Xtd14i43SDdILDiIuNtc79ZL5uNC1elO6pibONtU2rB7AdCQHkLmN3CqICUzVrqQVV5vb",
+	"zg8optktQGLI8o1dfxF3i5RidD0WtJwRH1r0123wUiEpPGs7Ao0ORnDErvijaVNtUQQRgTByDmJCKOFS",
+	"qg+EYm2FXlnGv3GWZ5658Ok1PvHdDb9aJgZBrGnYHMNmCJ7FKNu9KwAXFHQHWEm0B7764xbordATmq8d",
+	"QfdHzONLzKHXmbWKcN/3QoaufAqqId0Or3avrhJQnmFtt7attsFujuFiujzLUmv9rpBcJaI73mqke/Ds",
+	"vm8B6TphLdO3I2AfHb+OYw7CY7PG5YeVNZomeBZDxiHC0msUqgvXtwmeHZbF9e2inHpbTnEU+N2o7Buy",
+	"hGp2XAxpZQCWINtNC28U87U5c5RT7lneevt3xR41KrqDt068h0GKAltwSIM23xweVnvZAY9YtwOP8C/M",
+	"U60U2/rWmKVPiZRIc/rqUvFnW/x63PEiyVV0F0rXLaN6ra1Sr6MIMq/t1177nPe3HdbddapTXmmzbcJD",
+	"1j+cZV5REM0huhB5GvhIkpibi5rusRUxz3wm77F2G/VLRrg6T/GV31pqvhLa8lViPgPpL2Bxc44jp1V0",
+	"HwmtBEitmop4NAchufW6bMPWh0pRrapwF1venZagfpMlOIIUqDzPWEKi5dp7W1f+2BTXBmnmN8BkHM5X",
+	"J9BTjDBub99WV8AFwbgdkpgYkuMaPtvNOqaBUhiswF875Pab0BWTUNgiZFyQ1t9Fm2IVMlnGEjZbuyQf",
+	"Xbnr8Sg3kds97igagkJxeoWvK1xsWHNs3bcLrquwWJ2fVpjHC4hxNdSiyhRjp1Q7vHuwWsFOFShuQcup",
+	"r0xmbY5WZKGVp8UiGrG4bxel8nWPpO4ixvDWaEbkPJ/sRyw9YBlQsYgOWPriIGIcDlxDerqdsN1CoSma",
+	"8+zF1dY3VWeKfXCLK+EqIT2UjSr5PoXGft9Gn6kR1jKF3bQZ06dtpW0ifsbZpjKsuuDh9u3CNgyEvS8r",
+	"GuMr7yJUS60DLJWshtZW0QRWas8SNsHJOVxlobuTWolzps/XYn1b5/2F4XhExPkcnyeF3/mqHkLEus8Z",
+	"Bx35G/tL6HCttvFWC2w0iLqMPTdRMT3bKGVxqYu26Z4fquWNba/RhDiP7V396pxUlJqVRd2ZBlDR6ldV",
+	"gJrS3VHJNqcDP3sZP+ZNVm/rPbzOUS1cEWKtKsgbLNGAbxisHgSFEFGbfTennhlsBXaD8+r6QK2RUqEo",
+	"5FJXPcAhaLeKQMiHUbs/dndhjEIHMR0GsO3WU/azwjtTzv4A2lfM1qRkM7NS/bLCFUVEmPQGZGqSzdh0",
+	"C3MsdHjCBIAiu9YoznUQGj6jpZNIzC6pIglFbAHcxEFglGKlrVMd6JABJyzeP6M6YE3nRlj5ioDGYlzN",
+	"9yDmLE9iNAGUU+uKNT6jmMaoIP2SJIkqIEAqsvQ4TSCvZ4fAQp7r/Fd9hXYlwr4baNQ84KRHhYyzBVHM",
+	"ahZujY9vUXSXcrwFijynVM1F5zt/U1777PpOeRFOwH8u3f6kpbnbsq1j0iozreKgssDlyq0IvuoK1cWg",
+	"mx03sI3OQnb2dyMCbfzhIUwJ1XjwH4pwQrCAnjaPCNOYqOH1rWeCcgM3RYWkCn/70HIFZUp8hKtQC5kS",
+	"Lj1NZr57gYr4d25qPi8bOgdO/LS4Y1F3QljWYuSxoLTcuSr01Jld+/r7v0LYgCRDs6l+6DWXK1ZTZ6Sw",
+	"I/OdfrwQ7n4a9XOAZ3JXCm5xBA7Q7DkL+3vd3sRv2/Wzu4v61pRUhRCmeiqK7+fYv6o2DnRn3ns6BrSD",
+	"m03De8+R0aDYtbdmXnov5xrkbI+XdSjZFTYarYtFpOaM6d1yqrcvUL/kQmniVJjfIvXn18AFif2R4pTQ",
+	"2f5PhoINNzDTiEuJ+IZRyVnyPYs9jrgJLCCp6bcjolSNcTG2GCb5TN+G6p8vMdf+yjrkajyaYqn3+gxT",
+	"HRhE1XFp7QSbXtfs5yXpI5fbsc1PyBbY0EvoPchLxj0eoHqgPbe7KYeAThb22C377+yZ2+LKmQvo4rdd",
+	"D2lwNKjqeKYnTg3Ettbi42sn7+jYw7zZWifZ48b4W2+xXU9uvdrEZfBKia+3oZx4rih1JjMrQV2+SuP3",
+	"ZYlpnZt+ArOcUg++io9bCMwGXR6RWe9leyvzytr18Gdv4Y5Ngne6LNgmy9WyWDtYqjULtatlsuy0iVuD",
+	"qtvbpUF7pvR1Z1CV2lwZ1Pd76MZQmaDVnSbgPlAx75zPOI7g3Bh56qf6Mrv5agOEnuuz/HkKacCLoCgi",
+	"LnEWuufG8bJv3xz+wwjdjG6RJUSG7+WbsbT61jc4Wc1pWBlzY4B+0htErdFg1F6x9c2s3nBcxmd/6LbJ",
+	"Eu9Jpql/1zbJORQ6kc6AVUks30kEsRjeqSrr3EhW01DrFB+WhGq6D03G5Rw42Gz5mlZtkdRZkTHXqXkJ",
+	"nemkr94cLpk/y7JpwDdsyZCQjOMZIE0+Epia/jpPxenr9zrp9bqjuV2UmvuAobcLaorF3hFuNr7J19uB",
+	"b9Nxrd5VQLcjoMc+6kj27dIFwINayWoe9wJiqqIGtxelxdm83oL+ud5EM6teuzITPqPr0WyhcBRTG1j4",
+	"HaoavXwCfNaMYMOhu/6+1/mb3JDe/A367d5+P9LL57u8Se5+8aE3jK0vfmv7RfDCd2bz6qwsC86I//ci",
+	"Ec7Gt2oruXR8Cr+qh6UfvRtc/86ML1CIXI9dZb3XDVsATxiOg243hRrXGF3zXk4vgpny+gQX01C/pZtp",
+	"58iGx0SFmqLrLkDb9nathjPhFNru+5LvIjSgQIkdaVDm5aFD7NuperpA3KgvuFnzwDWaTbHY2bESZ9t5",
+	"gfe/t9+Bo3fRRLHzdGpB53xc4yne5gK+ucvBzTp2b+agfV6A5dy8h9XBvaCbJ0EXn2wL4ipkm37XpWOB",
+	"z+G6gYGaC3bd88A5Yddcr1dG374VF+Jh8yNWRbx49O1K65setUwT2xy2SiK6nyIqhHtQbL5ucUipkhSc",
+	"th0dVCoTuEJsTy/lcPPFk1HdRcGHunQu7/Bo9QZvjrUVwqiZXHphVDse/COH3Gcw9Z05+phNV84gzSlq",
+	"tu+brGMcXeCZx0SNeTQP731JAvGqAoj9CmDjhsrVf91UiFTl/Y+qhba7PUFmfW4uxqMFcNHJ5ukMAbb8",
+	"2MxBcc1RHbgho2VCN5dfbkU8XFht+64iVys0dJcuVcI9jGc/byG+alSFZ25HDgvHWBrmaFAa5oziaLQJ",
+	"J+gXFgMpj8z+2wHbppFKlTqgg8MMJh0rbxLcJOM41k7WmM5MqqKULcz/NFJ5lAPYOnPZ2P2fVySwDspU",
+	"EZcWSjdSnYY+iKxMnhfzMppvIyUUBP1Il/M7lhB2ZD0nKywdZDTfSjYU9Hjny7W+A7nQOEM1lAhtsPI/",
+	"LukqokLxdvTpB1WNpjEeJQzHCC9m9h5EIMaNBcI2LtRJW1+rccBaJ5+TqV9FaZzWgs9eFpQ5/b/MYixJ",
+	"qr2VKKN7lX8dKHTkNIapv2N7KGzciLt0rKSv++42LkUdDn1zNZG9EqP2OVGu8zjq0MaCJXkK4bNlq+vG",
+	"3MCkNvuNJjv7LamF7cn2jHmvQNXv2zB8QYiP313b259jVFP/1FPVHgLZHZdEnDOezTENRc2FovpDhpbO",
+	"WFzJJsuS0i+rEhNeUrgGCWZi+uPBTmgAFebrltiokhZASKWfXeBESGcIPOZs5s8GRMS5fksVJ10ujTb0",
+	"rwlfIoU9b1yd0NCUvlCmEnZvYXhiOlyq5Q2GUOZpNqPYLD1xnYQWA40aljEjGK+nEzA78Mqgpu5VNk/K",
+	"7rWtnl4S7zkiBiEJxeszkKTEBR88W+M+UW0yNGD9su3P5mVgXxq24lHpNXeWtaejXbXgbpmKWdBtv1uy",
+	"wNpz17X+TOuVtrxDty9TeJZB2suI5rNT8zzFdE+pWPqFQrjKEmwm1z25FCHJTMgii6Kc64cAravOGc1M",
+	"j7VowPpdbh544OfHjx+PXQxixGJAX/xy8vbN/zx/8ezXMTq1L/58/SWaAQWuoyInS9Mn42RGqHuhesp4",
+	"gDrkI66qsRCZgG9OxJxxOW5OjcjTFPNlo3Gk2t1H6Eii0x8/fHp3eEbff/iIzMnRPEpdIUyyMJljBFcR",
+	"ZPKMqiFlOc+YAP0et75dJn+YVfkC9mf7Y5QLQmeqqjr0LQDZl03OKIUZk0SX/b9IACDPtL7Yf/mld8lW",
+	"WE0a87xwV3tmzgLYU4BbBhzle+qd5vFor57hVq090uVZlaXVD8/VucVZDtQPL1qeJXBBDC6HtXvL2nTe",
+	"5mDjpmGL47CbyMp+fid+VNWh9NBKqhPgU33s920UnxphPrWn2scOzsL1S7zm+9/29cTyWUWOiifTK9dK",
+	"K6dOHUet3U2v9GnEnDYlz/32JZvju1cm8plLcbtxjvIOeeHXpxZvTxNeeBTYfOGGaN9C3L9t/RzHMe+7",
+	"6Y/tC/7e0/Imjk8CeDf9wvRbJX3cR+doZKMo+g2ulbnD98vCG1yu8wQCnhI3smai+U7OPV5OPTUdlrT1",
+	"rbDG2vZ5p6AOCs/+UCmyxRaxQqFnl2j2tP3p2GV52DRKZjXfX8dIGU+aoG7RMs28FNctowqFpxBxbp9a",
+	"j4MebnYcLSXU5hlPlv7vvDy0etMsqo/nsWPQDjEkq89QFUNo0FsjrqSk2W3XFBSNydxNKgrX6BGdMr+w",
+	"vYDlziLKeeBFvg0jzU2kpCKwTa9uDrGPKGhMjlfolGW2kjpNIr1ip9HX7uTO5oeOQnK1EbzNTVwhobY4",
+	"kFQJ2WBR1qz9LtZ93ZrveL3fsVlvGt+x2Q9U8mXrVLgy4awAHhAUanmXEP+yQtsAd5UXcuPIbp+waiU4",
+	"FFtS2cF6bOTOWLuq+DUdtrrtOrtNAhcg1hOFKGQvDZhDikkj3U7oMFmWHRcdta1QcZgPRTKkmqrOtHbz",
+	"J6769javJ6xZwPTbRnqIYqu6rNom5oRKE0VWGCTIjDIOAuEkMQYJJDmmQscyIONAIryJ3YpMfPUuCI1J",
+	"hCWobrBs9CXQHNM4KWy35lV/kSfanqujFYRNNmfoipFtY77MgC+IYBxpeRHINkdskECdpgtY7pkYugwT",
+	"LowRJiZ0hhSIuL4/UP9vFti+LB+xJIFInqm5gL1LEgPCE5ZLY1x2Y6rSUS5Q4uIDPdFcsx6CuaHx10cl",
+	"IUnMYsb6VUZEpohIl79PcjKbAUcY2QbsYiKXDPCMVteFMonyLDCr1VR8jdUuZ8LZ7vFsxmGmF5RQydAH",
+	"44KtzWGAY8Sm6PUCk6S0j5mK+2dUv84tEKHI9Vi2HjP6RCIhWYZwCKgB8nv43IeEwrojR+WwspJzxs6O",
+	"WRacXOKl0NkVszGCBVCEp1Kvkx5bv5H1fRnc5BD3QKkRcW3K1ZGu0+UIQWYUYiSZ9y1rPOvprNItJYeT",
+	"Z2VmQZtiyPCZ4aqSU2qpBVcyCNrTWnmCK+4y7OzYcYTecanvqG52tg524oXCrQQ8M9K79D408Q+TBEcX",
+	"CRHS/TDT99Ha18WkBR2NR/9h+lMCWHsoqo0Bm2mx4Q3kD+MtyZieiN9zLCVwv425klNy9da7xw4eeB02",
+	"fHhsiyNd2fLNTX71Wj/T/w1s/S4w3+PlSiTBHewrtoWjorxGv4u36lDzoym8oukXDRbttQzgqEpucxu2",
+	"n1zY+JwJiYTaxVwiAwQ0zhihct+wSedAdowuGU9ivSXmlPyu99VKe4jEQCWZEuD7taeFye90//nTpy/3",
+	"nj1VTLCfT3Iq81dPn72CryfxS/xi8tVXL72CxYqJhtRaZkVUfNG3vn6t9yoiQbpGygffbmpO+eZHax92",
+	"mudDb2935fTqI6b7Wdg7FM9W0Cy3xfHbT3CHad7R/aBrdpN5apmaHczImonY7fg/FgKxwbf6d8e5jSwr",
+	"90JCfbv37JmWUHab3hd88SqGxXP6bN/Su29Gsf+sv7zCtySxojnEeQJt4Q2+bKP+c4s6SfO8X2h8UWlK",
+	"Ai4aJit0HkUgRLgUhav+ndupClzd6W/n9ozHeOiWwRRrHCB8+X7Lqe4YklFUcabu6gw3p843UfVpKcfr",
+	"G51/KG2g2WJ7cwO7KcvxLh70qQ6zhxStTo5PTtvv2wjqGmE+SV3tY3vLcWlCch3k6nwVs0tapnCthj2o",
+	"81I8WSJdzPyvLuxbTfMMWOiaMMMcJwkkARfT+pu0tmjnxO7Vnndj3Ky/adZ5PauEeCDzsRJ3X8bTTDFJ",
+	"mHlo1xu5UglDL52HiirTBK686/FJ+J5dv9X3rRUJR3rz9XkG4jzot4RNBEgozUpfk0OFpHAuUZyCyHDA",
+	"75Djy/OCrE47dVnDDajaR3C2NpbEerk9IqRo9a4OFI6A7mKxINmzoOrbFhK3JCYwVTtRik3a/5wTuVQS",
+	"PDUETrAg0WsLek2QloLq11KlmUupE6xMAHPgrrT511unCv39Xx+tUmGa0F+bbVxXLOTWbXZkhZ4xviOT",
+	"KKiIKh+92H/29f5TYwMGqjM3jV7sP91/OqqkVDzAGTlQrHvgGveq/TrnttJ8VVElAUy4AkpBzlkskMgz",
+	"JZvLywHj0G38ko0VizB6FI9ejf4GUs2DTdrj8nprYp4/fWr9a6RNQIWzLLF9HfxHGL3XLP7adFKuDz1z",
+	"9dF8+Mk4x2iT5y9Gcv2qfilnQ7IL43aWMV868jccsASdx5KDzDlFGP399MN79C+YoI+qrp6FKCFqZSJM",
+	"US4AYXV+UIQxbj3A9aNAMXBEKCJSoClLEnZJ6AxxE68i9s/oGf2ob2L0DxAjzhIwmTMhnUAcQ2xafqIF",
+	"0xMUJZikiExRimU0V40pWnLBz6grYl8E8K3PMRN6gfQozDNVOAUJXM2Vf87LIgcnirbR9bg5YSm+QnpO",
+	"kfPjGaMUX5E0T00+RPT85Vwbh0evRr/noPO32x2s4vlTrn154nr2NPWdt3x2ckOByM1OrOdpjNJcSDRR",
+	"i4ngipj7JOtrp1aNB6iyrQSImjLWlSidn8ZOQi60gR5FBl8lzXrdDMUhetxbox5qqPAcda9/vWH2MwgK",
+	"8N949NJ052ulIOtAFdJln3Up+8yUfdGl7AtT9mWXsi9V2a+60PuVoferLjSoQtXNRfNXZVv55VcFmOrW",
+	"8cuvatHa5NblnOGUVOS4V/j+a85ep0c3KX5rumILBLou6+6mybL2gTnNH+CJO1N4Bf1r9dnchJvrFCca",
+	"7K2yuZetpbTREvsEzCWczYDs7nFNFkpkkktanmdUX+DrwPmQQLZe0zbXuSb5BhfPlybowbDxy6ffdCn7",
+	"jSn7bZey3/YTD1tg2YIvDOcpBzCRHH48v9XfNeCMgmL2OQe+M3rMYaG1ySRBNhzGoVegGCJtgBJjHapn",
+	"NxhXTiCJL4AZve+M6tyMlScJTco3NIEp42q3XdaeNCwwr/hBb4tLISEdn9EKnZdK6dExgoBSTPFMqT4l",
+	"zLuxj5mCgX9q/POQeSKn67jiky3RwhcnIKTCbZAnFPj1/uByViw3YRJFa5VNEsALp8Gb1CrO5STEPIZh",
+	"LPegHswzRoKhnGIpgaozhbNKISLOKFDtUI/wDBPaic3cnA6M9vAZrYyICWmdFhqFVbffqZKoxeXLH+zr",
+	"dfp82a3KUZoBF4z2q2XfkROjGz0jVV+ru9eovWV0afOUSUBRn5FDSEAqSRpZgZVTpWVjGuvnjK1RQzsh",
+	"KiFnDe4GnNaGgKYk0Te2DemlOtwJRg2NogfYPqlB9KlwqovfJDLfsDQlUt53aXovpN6Bu/r2Gk5PjHWw",
+	"qlPU8BiwkNag+NZcGfdYbRZJkHtCcsBpfdXXPpLoXW+TkAtMOrOrvQQLuZeymEwJxHt8Gr148eJbiikL",
+	"3vBn2k1Rtfa/Z2fxny+v99Sf5+7PR/PnVe3PF2dn++r/no2/vf7yr//+63/5iX2cAjL3bLPHeQA32nDs",
+	"Xga9JchcrwC2wxH9uTuif24mhc9MUztwW2UXuVW8slrc8VQ3Wtvwvmq4gywrNKub16sab0Xf+k52xyut",
+	"XcnDdiDGTQANxYm+m2I0WeoT6es4RhhRuCzeUqtuXjbIoLyMwhnRBVfuqXhxsaLvLiDWFZ9wxuQTdQx9",
+	"ogh8Yi6zisoZZxEInQ7J9qRKuTZNGMOSRnPOKMvLajr/lJtUVUoAlUW0TL0NY96aY4EmABRl+SQhYg7x",
+	"vmqKCPudCPNYF8R6dN+d5U+fvohwRs7VP/W/7JCZvbRz6Z9a6B/rmVa/lvd8prspSZSGNz6je+jvjNBT",
+	"4y02DvY9xnEMsf1U/oy+0IYCt3jFKHVpfbFUNWx86bo7MgFbLd2pYexVPge7vMQC4UQ/sohwrbuiNx0q",
+	"tGFfmCKdz8mk3kJxrrYgZNJe1HrTYuvLdkPF3020RUPPX01v5hgBx6tzGLiNs7GmpZeB5DkELufg8twW",
+	"Twl9B3Sm2Px55/u6QTs3ATBXe06gmdlekYgmqiYoEk9gRoSxremShcSQDJmc4Q1AoxTSibbj9ZJ771Tj",
+	"6wVfnYYNJV+9kVsWfbXOu8k+PTfrhZ9ZDp/4q4s9W84v+HRf6yWfHkVIHOnubAimR9rpLtaJu9YOdirv",
+	"3tmwsrUCz1mdqx3sQNCxGPYuJdsrMvDfgby7EV2rjOX0KtOHeZoVVwvVUGX9YpJOSGnVLBMN3G4UKKIV",
+	"+9mn3jtvxQ8uwLKDxekUjBd6WedGzU61Ae7Aa+CzMCcVnsot5vOjyitZ/Zb9GMt5nxV/z2K4ndV2Ywqd",
+	"znSckYszN+fWcRkQT2Mbe/6o1J0CK6vwOciwnB/8WTglXx/8eUFofG1+uj7Iqhm+e54JP4nSs/PNyc9a",
+	"F6aU2Sy4lTQG2kXU+MQQrUnokG19gcmchjBGZGrC011WA2w2UJv2oOwqLA29qcv7W+wVcxRysZsFXlX5",
+	"idC4e2nVgeWkLoa4fkzknQgPM70xOYzNBmR5yvGSzVugtNxpokMUjDqnG1PKnE0lUl3omMR6zfT6Qry/",
+	"ogJcD4eVFu5tOa105edS57hRbraZQaxKX2DHpnYBqpOCYJfrYh2vbqi7PARObUyBh0fVOrpLyyKxxcBV",
+	"G+yJFOQl4xdtGtV7U0SsOw5V06uUJ7wJji4U9l1HgbORTb5a4OM2PbDtANfZvj/jhXeTv7LuByTrsPRH",
+	"xw997Y+OH9fq21SC6y60rN4zLrJe0dieL1CMJdar3eaQrSBkTb89j+C3drZSPbm1f0x7gYZAHRHNwDb/",
+	"Wt50OFrZyQPlRs/EKxF48KfLTn7dO+LCvK0ijXmzGWLhVTOPoRkjsZGeyWKoqIKD7+oD8F3tgc8oAcxb",
+	"Qj/VZ2Gs8gJ9UXHxHmuXaYi/dA6ItdAffcoOAVdBzgBXN39TwF3nffN09Ng3iwAmYo7r3hRtsudQFx5k",
+	"zyB7euOsY/iWEy77a3bBItRpOyh29kw+cXfgpyS+eQXX7vRRBNngqtwTaFku5gdY2IyyIYeIKQcxt/71",
+	"NC58wVxuKmPuV42gmIiILYAv99fsb8e5mL8WJlfrI0flI0JaTMTFtkBTbfTD2aHqdYDZ44FZETe0Dc4y",
+	"HF3gGfSDmg4gGrD2mLB2MbsbpF3MBpw9DpyJCNODIp7cpV5sBVxhdqhWQxGO5rB/Rt8UselItU2BmzxS",
+	"5lGN8lY40hkaTFYxqn8FBc/Kiw6cmAh23SK23aimXAYjEzCOGEf2BQA0BSxzDgJNsCpj75edkc/Cns5s",
+	"6HpXe8lphMthERADbzwS3lgKDlmrJfmNEbalEDZhLUXNddL2tOji1jD1lvFoOHA/RLz2SELS1bpTybAx",
+	"2HcGuBm4NdWFtVHpVT3BennZeL4HoS3YC96dqgg36gNfTPqQF6Q76Nfmn9EY2DSxx4bSsswiM76tDDdD",
+	"uppbhuWuctWYM1vXTDV3geYhsc2jFaydU9ysongfHU2Ra89FSurgUBZh42OnXSzHKNYBIlfLtk28mtbk",
+	"NrfwIZ/Og5bggWQ6NwG5IRXPI0vF00XKmnAbZymoPFYbsvXqAtVIHX080tK1kolFC1f9PgSN0YKVr/YK",
+	"JWyVII5MVJg7PNlUBODC5PURjTL92JqO82E5r+UdNZFjQt9tLNEl0V7T8oxKvtQ3HjbTaZn71Mav25el",
+	"1ShCFt5DPbCT4s3XwR/uVqCKDiyk+mFWzHOpn5IKgvZ0nkv92lQRCB+Gp05bS82jyrU40DN6vALOGkDr",
+	"aXEz4ITF4zpAJV+eUS84sUCCMar+yjkQXka7uVg4O0pL0BNxRl0CCPVzO5RP3RT1xfKhe/6iexzbrVgq",
+	"zLCOyaBLb8c6kmUtbOPhgY1k+9aSXWFdergmp5IkNql0Uf98xnEE54YBFX/AVUY4xGtYRE3FfTbODZDf",
+	"DvIxFQdxnmbtmVKq+eYO35+iPxjVp0q1foHToVmYw/enqoH7DaH3p/9mFB7wBW5fUOgsUK0vjwE18s4q",
+	"u7qCaAPCD7rELdjG+uzN70hKZJeCmvq3OitW5+JvcDSHm8roI+FKmmXynkrb4K6JG0zGGzPHfOK+VC+T",
+	"Ox8RLcfMJ+g31cBvSpP9zXXyW/tu/CNgLieA5a4OYV3V16Lj4ex2B9hag6zT3eHqdEDVI0LV2lPOjjC1",
+	"gyPEAKn7BalE64DAd7EVurY2ANk7W/W290PX74CyO0NZn01xBwg7HfD12PDVdXvcCbpucY8cwHV34ErY",
+	"7EAd4zlL2nMX1PHxjs3e2Fp3iJLdZ+Arx6Wb9RgkTkEivMJpCZuhBBaQGPbqlJFvQPTWiO4J3t2B9s7g",
+	"pwPpLfgc5gbA3Tzg+CQ+wEnCzLIGTdF/sy96q/LWpx2lhDKOaJ5OtHc8jVHGuKw8gWKaLT3YrYdGyMXt",
+	"8OT7w9clKff6JqNO6k7su/fHJUdhYsWtvJGMBWQ0R1POUoTNBQU22Fj140VTjmdp+P7KLf2tOfWWnd0O",
+	"UOzAhkuA0uvQr+rbYPHOgFKF9d1/krQFy949uG4m93l9bDY+zQczm4ZtyKi8MwGp9j+xdrM0F7e2cEjy",
+	"6c/3e7PTJA4XmZ3x0TGNfZdHT27tFHqbCeZv+FGVIwnp8KhKr8NCMS0HSCyi0djz+0KfLld/j6Yz7+8C",
+	"/O3kgu+If5wBccJYi336e2ajbuzrAq7x/dbHGkz8tar70Diwc0Ta6yQ5TfCiV9jbz1h09NzxRtV3r9ar",
+	"dO9hnOYTAbJHhY941qc0ux1BOCQR2Era7VZKxTqGNCynbNDshpLK1H60sur2knMMvHVjmkRIYwhpGLvX",
+	"JHqkIN6AR28xI/Gj1Sd69zBIjke9K+t8PsLefPiZ/tgV8fI9+pcJ18MSzhlNlqiAGCIC6QeB9etz5Xt0",
+	"RZcQ21AjImzEUtxFjBT0DJKkTwoPk1vphCXJBEcXN5iX7p1Ob/AID00Kyx9oshwOWoNIv1ORvtYrdkZ0",
+	"gB2mMeIggC8ar8OKSBAUgw3yFC5sX1N/Act1L31aOX1yu66Mg5SGwVI1CNBBgO5CgLa55B5yllm5ic3j",
+	"2EaQKqnK7S9zSIocmU5sOjcgr5jtLlNv0YF3EKmDSB1E6iBStxepuZgfuJzAxaus27yf0bBDlAmHVeM8",
+	"NQkIu0jUXMxPbF37EOxwhXDfOHTguo24rlc2uQ0M+rcdDDmoI4M6MqgjgzqyvWDMW+47TnLvTQeSWFx0",
+	"kor5cDPRh8G1+zZP+9TgXTMiDoLzRgVn97cN6EIMcvbRydluqWF1WtUNVdCNM6s+Zok7CMRBkxwk3G4k",
+	"XJfkMJvKtuFwPRyuB5E4iMTPUCSqGvFkuYFkRES7E6raKA2+hOmRlKe2y0FgDgJzEJiDwPycBKbMO77v",
+	"3hSWpm5HGal6Ga43hziHR8ljnV5a2eiUNjhkDdanQXMYpNodSLUljQ4InYFosUEd6e+lg9QCc51GSiAO",
+	"EZBF+Zi7anVR9U9d0gjlWYyl+dbNo+p0SSPT56Bs3KgE2kigDDLikcmInK6L6v5kS2yqAbn6gxY0RHYP",
+	"fH9/+L5DbPenstA9ie6uUDTIkyFK+0aCroej2yCe70w8RwlgHpbIb9RnhCkCzhlHX5yNjIv+FJME4rMR",
+	"mjKO4AqnWQJfItKIKHTZHN3Lv60CV3f1SBJsDjj/XJNcmkSlB1OSQDDh8AnInNc0GG/WbJYi1/8+OpoW",
+	"/1AqCrVZMhMW4UR/GaOYKXXmahlI3F7wke7rrSLwUWerZZEE/yuxJiJv9Go0IRTz5Wg8kssMRq9GQnJC",
+	"Q6nhx6O5VlJ011d7CRZyL2Wxfrd8j0+jFy9efEsxZbUeYixhT5LUrIVUWuno1eh/z87iP19e76k/z92f",
+	"j+bPq9qfL87O9tX/PRt/e/3lX//91//yEzvIjs9BdiQs/ILDqU57QuESJWwm2jn8HZs9wpvTd2zW/SVq",
+	"VZglCbvsWPgdoSBu+AFq3c2Qtf1z5+KVuPF1OkAtFhxJPEkAsanXwNHO9w85MPwmT5zVeRs48O7Ommo9",
+	"4ryb4uzKbsMvp66/gVc684qbs/vPJy+fvuxS9uUD5ymJJRTHUWfEqZ1UOCRYkgXsqaa0DtM4QLRZZbRF",
+	"88EeJru8BLXrc+TqM08vu7ya+PJz5LuXT7/tUvbbz5NHtz3PKd64pbPcbRye1pdVVN+DU9YDf+8qU7In",
+	"hEssLkwGQMmQKohwkqAoyXUGVvVBtLwLeaxa3v3baJ+X/Ls367y9Or3mBdid6c+Dwnq/gCPmB3Mm5AUs",
+	"RSfwiDnK8klCIqSqIVUPCZMGLwPgKMIUSZ4LfWeRIkIRkQJdUHZJz1UNoa882pB2+uOPjqCbB5veXbIE",
+	"kwbMOmpvA5YaWLqAZU8YXcASxTAl1Hj7ajkkxFz97McVkQ5VOJdzxskfEJ9rHK5H1k+wHED12YFKr7s+",
+	"0+YeWH100qaBKqG2No2doC5znDtg6EbuWJ956Cu5FBLSg5iIi6CI+CeBS/OavSoV4mPd0KEpcY8f5yXi",
+	"YtBE+sJjxlmerceHKdYKkL/ZIvcXIZrCASJ9ITLHPL7EHNajxJUU7Uj50TV4n8HiiBzw0hcvJMNxzEGI",
+	"nYiVo+PXtrX7jJaCygEufeGS4egCzzpIF1ewFS7HRaH7CxZL4wCV/lCR0bwLUFSxNTAxRe4zSGQ0HyDS",
+	"GyJcrbpcdkCJK9kOlLLUPcaKJXKAS1+4CEwPCCWSYMn4esyURVtBc/r6/VGl5D224L9+rzoriB0AtAmA",
+	"nHNHO3Yk5jOQYi1y1IJ8DqAZsNIXK7mADjJGlVqDkk+qofsMEUXggI8gPirQsEFNF7C8ZDzudCeYECER",
+	"myKRZxnjEmLkaiNCtfE9fCdjIpR+cr3dZwxZIg9hqnddRu8GUHcBEuNrG8SCmgjtPGLKCRf8aX1JAldy",
+	"H0zh3muuVvyD7honN7vihsJBbmhIWAw0QdGubHikhPXbVtUEStWh0j3iLMC+ogdXGQehUz/MyAKoywKl",
+	"6pR5HlphZdzLNoHWbUDKOr89SLe0NpzUnJfFInKey7FJ9tvysK0poFFwOWcJILGIEONIsFS7MBEpiuCa",
+	"QNLR00Vkm9l0m+nvjdw3O9edpNkafO4CILYuwb2gDLQdyT/QXQDZtDLgeMDxTnFciyepbOqBTfb28Hff",
+	"QqPM+I8kpA96Fy9iIop/miDc4p8m9rYsDLXC9UjbTqBzOcLwhNVfr1kVg2YNbOogXfzxwpFHc3BP/P8j",
+	"h/y+J1HqFzj0TZey39zLIKO75qMYEpDQnZEOTfmBkwZOGjipxkmruWrbOentVplnB04aOOkuOGlD5piR",
+	"Behnmjqzx99cjYFBBga5zwyyIUd4Uxy3s8TxtumFB54YeOIz2jSynM+gWwbwwiKKMI2ROdRUsgDtn9FD",
+	"Ii70x2nFformLIlRjCXeR9/DJeYwRpXs4ygXOU6SpW1QmMgjVfqMHud8pmPitYE2ZmAScWqadbkFK+87",
+	"c1E+VSIWUSi9bY3Z9eAHRh8Y/eEzOoeVx6jbmePEVrj/7NEla1BP39nAXGjuUB0SDvHoleQ5XA8MOmin",
+	"G3FkT348/Uy4ceCFgRc24IX6A5zrWGHzRzUHThg44V5zwiWx8WwdecGUH7S0YioGJW1gx52x4/r3EV8n",
+	"CbtEOJcsxZJE+iketgCuvfEXEbokco5+YwVK4Ls5/m3/jJp6cg7o95zxPEULJkG/3yPn+sURnQuuLOUe",
+	"7zGEocs5UPSb/fE7BfLfqhYaDiiGGccxxNoiQ5l+41XpkHiSQBfryLYPNw477cDan5GBpPeLiHV76AVA",
+	"Fnxi6AZsoxVKPCbSvPFy45aG0h08uzhIg0EafA7SwPDter9bEzR3v7mhszP3Dwuc5Fj2qXKUZsAFo/1q",
+	"FUGGtxElOASN7dppSz+aZk6njdggcxsoQG8XQu1iAqTe79Tfaixq6zN8nmAL1eEDZDkzY33emf2kprTX",
+	"w7S6+E0y2huWpkQOz8XeqW/kbp/AxNTk/zXnVoxiyBK2hLjy6vc7xi7sQRV87Vids3wrE00JF1I/qtn4",
+	"MMdKXy3feai9K7T2ic2qWNjmTZThuczhuczPcCteYx/+rPhiePnnkb38s1tWyH2ckA+MMDDCY2KEjfTG",
+	"3WUZMt2uV9W2zTT0+ZsSe6cxumepie4MszGWeB1QMRKS55HMOcQFYi9gqa0RC5zkIJwtvPVccaj6ehjG",
+	"hp9gqUm64ccWsMQ/wVIn1XmUWv1WJrTXSBA6S2BPckyFveWNWKp2cv3/bIpwHI9RNMd0Bohx54Nf4Fe4",
+	"o/cFLPc00pGQjOt/+99eKY1r9x/tN+VFouagCt31ziOfm3b0EK52bmYvcW9llSH6Xrs21vuHto952MvH",
+	"WaZiyVpbPHp1P/eSIfnPTewNa/QavUFoLBr4YeMS4MhFExYv1+o0jwKKN2Za/byOvPdXCfK617zhgLW4",
+	"pXCpYU5oV4Fb2j0fMsZvwTr0sJSfe4l93wuKb4xWr521NNKVuk8RXBEhCZ315YZ8YIaBGe4/M2ymsYv2",
+	"LNiWR0QPfmkqSI/YNmlnwFkkP0MT/+cOc+cefEDolHUxy7sKSFUon5Qvs8EXDhbtFs8T286R6vfRMkB1",
+	"FgYXwp072KppjvNuvkqubB3TFS+mbrg+dV0+Wky7Gbj/eL6/gr4d+xlQnJE2v/HTSzyb6Td6tlpmq6Xa",
+	"FP/3O/Oxm0PzIHxlujLGkra5OmYs8ehg9YEqOaBkipYLaIKjC6Cx1vHwDJDuYjwiquTv6vAwGo9U6dEr",
+	"82e8OqeF5n+j7/IxluzuuvfebRV62usLfbBgSZ7CuvX+py71gFfdDPDxrD2HBC8PUhCi/pTvyuqfqII/",
+	"23J992hd+b19O6vLnqsrvDHPIh0ddq7xSQCnt6B8VqbiYaJEw2KNB2sDETeVPWDdbCsCETau6jGWWIC0",
+	"XvJIjwLNAXM5ASxHHVMOrLMVPX1U5woHhbrEEBLLPGzj+RtIZIWKcEcCXbEe2mqojAmduVj6jzr2YEbo",
+	"QYaFuGQ8NhUkQ1OQ0Vwfn3lqvC0wN8ZYobYa9T/FUutuAucNDahTQ/9Ggkx0lkcnkDJ5G9LIDOcBb1ur",
+	"KDQGgPYty4Zwb/l03vrFVltbn/InJL6dl/ncFISQMQNZWqaMs+m4zGKhdTbNJ49L4Flo/Xp9fX39/wMA",
+	"AP//dNQagoo9AgA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/daemon/api/codegen_type_gen.go
+++ b/daemon/api/codegen_type_gen.go
@@ -1477,6 +1477,9 @@ type InQueryDeletes = []string
 // InQueryDisableRollback defines model for inQueryDisableRollback.
 type InQueryDisableRollback = bool
 
+// InQueryDriver defines model for inQueryDriver.
+type InQueryDriver = string
+
 // InQueryEnvs defines model for inQueryEnvs.
 type InQueryEnvs = []string
 
@@ -1504,11 +1507,17 @@ type InQueryLeader = bool
 // InQueryMaster Act on the host instance of the service, and don't act on encap instance if not asked for explicitely.
 type InQueryMaster = bool
 
+// InQueryOption defines model for inQueryOption.
+type InQueryOption = string
+
 // InQueryRequesterSid defines model for inQueryRequesterSid.
 type InQueryRequesterSid = openapi_types.UUID
 
 // InQueryRid defines model for inQueryRid.
 type InQueryRid = string
+
+// InQuerySection defines model for inQuerySection.
+type InQuerySection = string
 
 // InQuerySets defines model for inQuerySets.
 type InQuerySets = []string
@@ -1585,6 +1594,18 @@ type PatchClusterConfigParams struct {
 	Delete *InQueryDeletes `form:"delete,omitempty" json:"delete,omitempty"`
 	Unset  *InQueryUnsets  `form:"unset,omitempty" json:"unset,omitempty"`
 	Set    *InQuerySets    `form:"set,omitempty" json:"set,omitempty"`
+}
+
+// GetClusterConfigKeywordsParams defines parameters for GetClusterConfigKeywords.
+type GetClusterConfigKeywordsParams struct {
+	// Driver show only keywords of this driver
+	Driver *InQueryDriver `form:"driver,omitempty" json:"driver,omitempty"`
+
+	// Section show supported keywords of this configuration section
+	Section *InQuerySection `form:"section,omitempty" json:"section,omitempty"`
+
+	// Option show the keyword referenced by section and option
+	Option *InQueryOption `form:"option,omitempty" json:"option,omitempty"`
 }
 
 // PostClusterJoinParams defines parameters for PostClusterJoin.
@@ -1688,6 +1709,18 @@ type PatchNodeConfigParams struct {
 	Delete *InQueryDeletes `form:"delete,omitempty" json:"delete,omitempty"`
 	Unset  *InQueryUnsets  `form:"unset,omitempty" json:"unset,omitempty"`
 	Set    *InQuerySets    `form:"set,omitempty" json:"set,omitempty"`
+}
+
+// GetNodeConfigKeywordsParams defines parameters for GetNodeConfigKeywords.
+type GetNodeConfigKeywordsParams struct {
+	// Driver show only keywords of this driver
+	Driver *InQueryDriver `form:"driver,omitempty" json:"driver,omitempty"`
+
+	// Section show supported keywords of this configuration section
+	Section *InQuerySection `form:"section,omitempty" json:"section,omitempty"`
+
+	// Option show the keyword referenced by section and option
+	Option *InQueryOption `form:"option,omitempty" json:"option,omitempty"`
 }
 
 // PostDaemonShutdownParams defines parameters for PostDaemonShutdown.
@@ -1985,6 +2018,18 @@ type PatchObjectConfigParams struct {
 	Delete *InQueryDeletes `form:"delete,omitempty" json:"delete,omitempty"`
 	Unset  *InQueryUnsets  `form:"unset,omitempty" json:"unset,omitempty"`
 	Set    *InQuerySets    `form:"set,omitempty" json:"set,omitempty"`
+}
+
+// GetObjectConfigKeywordsParams defines parameters for GetObjectConfigKeywords.
+type GetObjectConfigKeywordsParams struct {
+	// Driver show only keywords of this driver
+	Driver *InQueryDriver `form:"driver,omitempty" json:"driver,omitempty"`
+
+	// Section show supported keywords of this configuration section
+	Section *InQuerySection `form:"section,omitempty" json:"section,omitempty"`
+
+	// Option show the keyword referenced by section and option
+	Option *InQueryOption `form:"option,omitempty" json:"option,omitempty"`
 }
 
 // GetObjectDataParams defines parameters for GetObjectData.

--- a/daemon/api/codegen_type_gen.go
+++ b/daemon/api/codegen_type_gen.go
@@ -101,6 +101,11 @@ const (
 	InstanceListKindInstanceList InstanceListKind = "InstanceList"
 )
 
+// Defines values for KeywordDefinitionListKind.
+const (
+	KeywordDefinitionListKindKeywordDefinitionList KeywordDefinitionListKind = "KeywordDefinitionList"
+)
+
 // Defines values for KeywordListKind.
 const (
 	KeywordListKindKeywordList KeywordListKind = "KeywordList"
@@ -628,6 +633,39 @@ type InstanceMonitor = instance.Monitor
 
 // InstanceStatus defines model for InstanceStatus.
 type InstanceStatus = instance.Status
+
+// KeywordDefinitionItem defines model for KeywordDefinitionItem.
+type KeywordDefinitionItem struct {
+	Aliases       *[]string `json:"aliases,omitempty"`
+	Candidates    *[]string `json:"candidates,omitempty"`
+	Converter     *string   `json:"converter,omitempty"`
+	Default       *string   `json:"default,omitempty"`
+	DefaultOption *string   `json:"defaultOption,omitempty"`
+	DefaultText   *string   `json:"defaultText,omitempty"`
+	Depends       *[]string `json:"depends,omitempty"`
+	Deprecated    *string   `json:"deprecated,omitempty"`
+	Example       *string   `json:"example,omitempty"`
+	Inherit       *string   `json:"inherit,omitempty"`
+	Kind          *[]string `json:"kind,omitempty"`
+	Option        string    `json:"option"`
+	Provisioning  *bool     `json:"provisioning,omitempty"`
+	Scopable      *bool     `json:"scopable,omitempty"`
+	Section       string    `json:"section"`
+	Text          *string   `json:"text,omitempty"`
+	Types         *[]string `json:"types,omitempty"`
+}
+
+// KeywordDefinitionItems defines model for KeywordDefinitionItems.
+type KeywordDefinitionItems = []KeywordDefinitionItem
+
+// KeywordDefinitionList defines model for KeywordDefinitionList.
+type KeywordDefinitionList struct {
+	Items KeywordDefinitionItems    `json:"items"`
+	Kind  KeywordDefinitionListKind `json:"kind"`
+}
+
+// KeywordDefinitionListKind defines model for KeywordDefinitionList.Kind.
+type KeywordDefinitionListKind string
 
 // KeywordItem defines model for KeywordItem.
 type KeywordItem struct {

--- a/daemon/daemonapi/get_cluster_config_keywords.go
+++ b/daemon/daemonapi/get_cluster_config_keywords.go
@@ -9,10 +9,29 @@ import (
 	"github.com/opensvc/om3/daemon/api"
 )
 
-func (a *DaemonAPI) GetClusterConfigKeywords(ctx echo.Context) error {
+func (a *DaemonAPI) GetClusterConfigKeywords(ctx echo.Context, params api.GetClusterConfigKeywordsParams) error {
+	var (
+		err    error
+		status int
+	)
+	store := object.KeywordStoreWithDrivers(naming.KindCcfg)
+	store, status, err = filterKeywordStore(ctx, store, params.Driver, params.Section, params.Option, naming.Cluster, func() (configProvider, error) {
+		var (
+			i   any
+			err error
+		)
+		i, err = object.NewCluster(object.WithVolatile(true))
+		if err != nil {
+			return nil, err
+		}
+		return i.(configProvider), nil
+	})
+	if err != nil {
+		return JSONProblemf(ctx, status, http.StatusText(status), "%s", err)
+	}
 	r := api.KeywordDefinitionList{
 		Kind:  "KeywordDefinitionList",
-		Items: convertKeywordStore(object.KeywordStoreWithDrivers(naming.KindCcfg)),
+		Items: convertKeywordStore(store),
 	}
 	return ctx.JSON(http.StatusOK, r)
 }

--- a/daemon/daemonapi/get_cluster_config_keywords.go
+++ b/daemon/daemonapi/get_cluster_config_keywords.go
@@ -1,0 +1,18 @@
+package daemonapi
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/opensvc/om3/core/naming"
+	"github.com/opensvc/om3/core/object"
+	"github.com/opensvc/om3/daemon/api"
+)
+
+func (a *DaemonAPI) GetClusterConfigKeywords(ctx echo.Context) error {
+	r := api.KeywordDefinitionList{
+		Kind:  "KeywordDefinitionList",
+		Items: convertKeywordStore(object.KeywordStoreWithDrivers(naming.KindCcfg)),
+	}
+	return ctx.JSON(http.StatusOK, r)
+}

--- a/daemon/daemonapi/get_node_config_keywords.go
+++ b/daemon/daemonapi/get_node_config_keywords.go
@@ -1,108 +1,38 @@
 package daemonapi
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	"github.com/opensvc/om3/core/keywords"
+	"github.com/opensvc/om3/core/naming"
 	"github.com/opensvc/om3/core/object"
 	"github.com/opensvc/om3/daemon/api"
 )
 
-func (a *DaemonAPI) GetNodeConfigKeywords(ctx echo.Context, nodename string) error {
+func (a *DaemonAPI) GetNodeConfigKeywords(ctx echo.Context, nodename string, params api.GetNodeConfigKeywordsParams) error {
+	var (
+		err    error
+		status int
+	)
+	store := object.NodeKeywordStore
+	path := naming.Path{}
+	store, status, err = filterKeywordStore(ctx, store, params.Driver, params.Section, params.Option, path, func() (configProvider, error) {
+		var (
+			err error
+			i   any
+		)
+		i, err = object.NewNode(object.WithVolatile(true))
+		if err != nil {
+			return nil, err
+		}
+		return i.(configProvider), nil
+	})
+	if err != nil {
+		return JSONProblemf(ctx, status, http.StatusText(status), "%s", err)
+	}
 	r := api.KeywordDefinitionList{
 		Kind:  "KeywordDefinitionList",
-		Items: convertKeywordStore(object.NodeKeywordStore),
+		Items: convertKeywordStore(store),
 	}
 	return ctx.JSON(http.StatusOK, r)
-}
-
-func convertKeywordStore(store keywords.Store) api.KeywordDefinitionItems {
-	l := make(api.KeywordDefinitionItems, 0)
-	for _, kw := range store {
-		item := api.KeywordDefinitionItem{
-			Option:  kw.Option,
-			Section: kw.Section,
-		}
-
-		if len(kw.Aliases) > 0 {
-			aliases := append([]string{}, kw.Aliases...)
-			item.Aliases = &aliases
-		}
-
-		if len(kw.Candidates) > 0 {
-			candidates := append([]string{}, kw.Candidates...)
-			item.Candidates = &candidates
-		}
-
-		if len(kw.Depends) > 0 {
-			var depends []string
-			for _, d := range kw.Depends {
-				depends = append(depends, d.String())
-			}
-			item.Depends = &depends
-		}
-
-		if len(kw.Kind) > 0 {
-			var kind []string
-			for _, k := range kw.Kind {
-				switch v := k.(type) {
-				case string:
-					kind = append(kind, v)
-				case fmt.Stringer:
-					kind = append(kind, v.String())
-				default:
-					kind = append(kind, fmt.Sprintf("%v", v))
-				}
-			}
-			item.Kind = &kind
-		}
-
-		if len(kw.Types) > 0 {
-			types := append([]string{}, kw.Types...)
-			item.Types = &types
-		}
-
-		if kw.Converter != nil {
-			convType := fmt.Sprintf("%T", kw.Converter)
-			item.Converter = &convType
-		}
-
-		if kw.Default != "" {
-			item.Default = &kw.Default
-		}
-
-		if kw.DefaultOption != "" {
-			item.DefaultOption = &kw.DefaultOption
-		}
-
-		if s := kw.DefaultText.String(); s != "" {
-			item.DefaultText = &s
-		}
-
-		if s := kw.Text.String(); s != "" {
-			item.Text = &s
-		}
-
-		if kw.Example != "" {
-			item.Example = &kw.Example
-		}
-
-		if kw.Deprecated != "" {
-			item.Deprecated = &kw.Deprecated
-		}
-
-		if kw.Provisioning {
-			item.Provisioning = &kw.Provisioning
-		}
-
-		if kw.Scopable {
-			item.Scopable = &kw.Scopable
-		}
-		s := kw.Inherit.String()
-		item.Inherit = &s
-		l = append(l, item)
-	}
-	return l
 }

--- a/daemon/daemonapi/get_node_config_keywords.go
+++ b/daemon/daemonapi/get_node_config_keywords.go
@@ -1,0 +1,108 @@
+package daemonapi
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/opensvc/om3/core/keywords"
+	"github.com/opensvc/om3/core/object"
+	"github.com/opensvc/om3/daemon/api"
+)
+
+func (a *DaemonAPI) GetNodeConfigKeywords(ctx echo.Context, nodename string) error {
+	r := api.KeywordDefinitionList{
+		Kind:  "KeywordDefinitionList",
+		Items: convertKeywordStore(object.NodeKeywordStore),
+	}
+	return ctx.JSON(http.StatusOK, r)
+}
+
+func convertKeywordStore(store keywords.Store) api.KeywordDefinitionItems {
+	l := make(api.KeywordDefinitionItems, 0)
+	for _, kw := range store {
+		item := api.KeywordDefinitionItem{
+			Option:  kw.Option,
+			Section: kw.Section,
+		}
+
+		if len(kw.Aliases) > 0 {
+			aliases := append([]string{}, kw.Aliases...)
+			item.Aliases = &aliases
+		}
+
+		if len(kw.Candidates) > 0 {
+			candidates := append([]string{}, kw.Candidates...)
+			item.Candidates = &candidates
+		}
+
+		if len(kw.Depends) > 0 {
+			var depends []string
+			for _, d := range kw.Depends {
+				depends = append(depends, d.String())
+			}
+			item.Depends = &depends
+		}
+
+		if len(kw.Kind) > 0 {
+			var kind []string
+			for _, k := range kw.Kind {
+				switch v := k.(type) {
+				case string:
+					kind = append(kind, v)
+				case fmt.Stringer:
+					kind = append(kind, v.String())
+				default:
+					kind = append(kind, fmt.Sprintf("%v", v))
+				}
+			}
+			item.Kind = &kind
+		}
+
+		if len(kw.Types) > 0 {
+			types := append([]string{}, kw.Types...)
+			item.Types = &types
+		}
+
+		if kw.Converter != nil {
+			convType := fmt.Sprintf("%T", kw.Converter)
+			item.Converter = &convType
+		}
+
+		if kw.Default != "" {
+			item.Default = &kw.Default
+		}
+
+		if kw.DefaultOption != "" {
+			item.DefaultOption = &kw.DefaultOption
+		}
+
+		if s := kw.DefaultText.String(); s != "" {
+			item.DefaultText = &s
+		}
+
+		if s := kw.Text.String(); s != "" {
+			item.Text = &s
+		}
+
+		if kw.Example != "" {
+			item.Example = &kw.Example
+		}
+
+		if kw.Deprecated != "" {
+			item.Deprecated = &kw.Deprecated
+		}
+
+		if kw.Provisioning {
+			item.Provisioning = &kw.Provisioning
+		}
+
+		if kw.Scopable {
+			item.Scopable = &kw.Scopable
+		}
+		s := kw.Inherit.String()
+		item.Inherit = &s
+		l = append(l, item)
+	}
+	return l
+}

--- a/daemon/daemonapi/get_object_config_keywords.go
+++ b/daemon/daemonapi/get_object_config_keywords.go
@@ -6,13 +6,44 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/opensvc/om3/core/naming"
 	"github.com/opensvc/om3/core/object"
+	"github.com/opensvc/om3/core/xconfig"
 	"github.com/opensvc/om3/daemon/api"
 )
 
-func (a *DaemonAPI) GetObjectConfigKeywords(ctx echo.Context, namespace string, kind naming.Kind, name string) error {
+type (
+	configProvider interface {
+		Config() *xconfig.T
+	}
+)
+
+func (a *DaemonAPI) GetObjectConfigKeywords(ctx echo.Context, namespace string, kind naming.Kind, name string, params api.GetObjectConfigKeywordsParams) error {
+	var (
+		err    error
+		status int
+	)
+	store := object.KeywordStoreWithDrivers(kind)
+	path := naming.Path{
+		Name:      name,
+		Namespace: namespace,
+		Kind:      kind,
+	}
+	store, status, err = filterKeywordStore(ctx, store, params.Driver, params.Section, params.Option, path, func() (configProvider, error) {
+		var (
+			i   any
+			err error
+		)
+		i, err = object.NewConfigurer(path, object.WithVolatile(true))
+		if err != nil {
+			return nil, err
+		}
+		return i.(configProvider), nil
+	})
+	if err != nil {
+		return JSONProblemf(ctx, status, http.StatusText(status), "%s", err)
+	}
 	r := api.KeywordDefinitionList{
 		Kind:  "KeywordDefinitionList",
-		Items: convertKeywordStore(object.KeywordStoreWithDrivers(kind)),
+		Items: convertKeywordStore(store),
 	}
 	return ctx.JSON(http.StatusOK, r)
 }

--- a/daemon/daemonapi/get_object_config_keywords.go
+++ b/daemon/daemonapi/get_object_config_keywords.go
@@ -1,0 +1,18 @@
+package daemonapi
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/opensvc/om3/core/naming"
+	"github.com/opensvc/om3/core/object"
+	"github.com/opensvc/om3/daemon/api"
+)
+
+func (a *DaemonAPI) GetObjectConfigKeywords(ctx echo.Context, namespace string, kind naming.Kind, name string) error {
+	r := api.KeywordDefinitionList{
+		Kind:  "KeywordDefinitionList",
+		Items: convertKeywordStore(object.KeywordStoreWithDrivers(kind)),
+	}
+	return ctx.JSON(http.StatusOK, r)
+}

--- a/daemon/daemonapi/lib_config_keywords.go
+++ b/daemon/daemonapi/lib_config_keywords.go
@@ -1,0 +1,142 @@
+package daemonapi
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/opensvc/om3/core/keywords"
+	"github.com/opensvc/om3/core/naming"
+	"github.com/opensvc/om3/daemon/api"
+	"github.com/opensvc/om3/util/key"
+)
+
+func filterKeywordStore(ctx echo.Context, store keywords.Store, driver, section, option *string, path naming.Path, getConfigProvider func() (configProvider, error)) (keywords.Store, int, error) {
+	var err error
+	switch {
+	case driver == nil && section == nil && option == nil:
+	case driver != nil && section != nil && option == nil:
+		return nil, http.StatusBadRequest, fmt.Errorf("driver and section filters are mutually exclusive")
+	case driver != nil && section == nil && option == nil:
+		l := keywords.ParseIndex(*driver)
+		store, err = store.DriverKeywords(l[0], l[1], path.Kind)
+		if err != nil {
+			return nil, http.StatusInternalServerError, err
+		}
+	case driver == nil && section != nil && option == nil:
+		o, err := getConfigProvider()
+		if err != nil {
+			return nil, http.StatusInternalServerError, err
+		}
+		sectionType := o.Config().GetString(key.New(*section, "type"))
+		drvGroup, _, _ := strings.Cut(*section, "#")
+		store, err = store.DriverKeywords(drvGroup, sectionType, path.Kind)
+		if err != nil {
+			return nil, http.StatusInternalServerError, fmt.Errorf("%s.%s: %s", drvGroup, sectionType, err)
+		}
+	case driver == nil && section != nil && option != nil:
+		o, err := getConfigProvider()
+		if err != nil {
+			return nil, http.StatusInternalServerError, err
+		}
+		sectionType := o.Config().GetString(key.New(*section, "type"))
+		k := key.New(*section, *option)
+		kw := store.Lookup(k, path.Kind, sectionType)
+		if kw.IsZero() {
+			store = []keywords.Keyword{}
+		} else {
+			store = []keywords.Keyword{kw}
+		}
+	}
+	return store, http.StatusOK, nil
+}
+
+func convertKeywordStore(store keywords.Store) api.KeywordDefinitionItems {
+	l := make(api.KeywordDefinitionItems, 0)
+	for _, kw := range store {
+		item := api.KeywordDefinitionItem{
+			Option:  kw.Option,
+			Section: kw.Section,
+		}
+
+		if len(kw.Aliases) > 0 {
+			aliases := append([]string{}, kw.Aliases...)
+			item.Aliases = &aliases
+		}
+
+		if len(kw.Candidates) > 0 {
+			candidates := append([]string{}, kw.Candidates...)
+			item.Candidates = &candidates
+		}
+
+		if len(kw.Depends) > 0 {
+			var depends []string
+			for _, d := range kw.Depends {
+				depends = append(depends, d.String())
+			}
+			item.Depends = &depends
+		}
+
+		if len(kw.Kind) > 0 {
+			var kind []string
+			for _, k := range kw.Kind {
+				switch v := k.(type) {
+				case string:
+					kind = append(kind, v)
+				case fmt.Stringer:
+					kind = append(kind, v.String())
+				default:
+					kind = append(kind, fmt.Sprintf("%v", v))
+				}
+			}
+			item.Kind = &kind
+		}
+
+		if len(kw.Types) > 0 {
+			types := append([]string{}, kw.Types...)
+			item.Types = &types
+		}
+
+		if kw.Converter != nil {
+			convType := fmt.Sprintf("%T", kw.Converter)
+			item.Converter = &convType
+		}
+
+		if kw.Default != "" {
+			item.Default = &kw.Default
+		}
+
+		if kw.DefaultOption != "" {
+			item.DefaultOption = &kw.DefaultOption
+		}
+
+		if s := kw.DefaultText.String(); s != "" {
+			item.DefaultText = &s
+		}
+
+		if s := kw.Text.String(); s != "" {
+			item.Text = &s
+		}
+
+		if kw.Example != "" {
+			item.Example = &kw.Example
+		}
+
+		if kw.Deprecated != "" {
+			item.Deprecated = &kw.Deprecated
+		}
+
+		if kw.Provisioning {
+			item.Provisioning = &kw.Provisioning
+		}
+
+		if kw.Scopable {
+			item.Scopable = &kw.Scopable
+		}
+		s := kw.Inherit.String()
+		item.Inherit = &s
+		l = append(l, item)
+	}
+	return l
+}


### PR DESCRIPTION
- GET /api/cluster/config/keywords
- GET /api/node/{nodename}/config/keywords
- GET /api/object/path/{namespace}/{kind}/{name}/config/keywords

Also:
- Rename storeWithDriverKeywords → KeywordStoreWithDrivers to make it public
- Rename nodeKeywordStore → NodeKeywordStore to make it public