### PR TITLE
Fix object create --wait errors and enhance error messages in wait instance functions

### DIFF
--- a/core/client/client.go
+++ b/core/client/client.go
@@ -36,7 +36,7 @@ type (
 
 var (
 	// DefaultClientTimeout is the default client timeout value used by New
-	DefaultClientTimeout = 5 * time.Second
+	DefaultClientTimeout = 30 * time.Second
 )
 
 // New allocates a new client configuration and returns the reference

--- a/core/omcmd/object_create.go
+++ b/core/omcmd/object_create.go
@@ -74,7 +74,10 @@ func (t *CmdObjectCreate) Run(kind string) error {
 	defer cancel()
 	var needWait bool
 	if t.Wait || t.Provision {
-		if err := commoncmd.WaitInstanceMonitor(ctx, t.client, t.path, 0, errC); err != nil {
+		// need dedicated client that override default client timeout with t.Timeout (zero means no timeout).
+		if c, err := client.New(client.WithTimeout(t.Timeout)); err != nil {
+			return err
+		} else if err := commoncmd.WaitInstanceMonitor(ctx, c, t.path, t.Time, errC); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				// the daemon is not running.
 			} else {

--- a/core/omcmd/object_create.go
+++ b/core/omcmd/object_create.go
@@ -77,7 +77,9 @@ func (t *CmdObjectCreate) Run(kind string) error {
 		// need dedicated client that override default client timeout with t.Timeout (zero means no timeout).
 		if c, err := client.New(client.WithTimeout(t.Timeout)); err != nil {
 			return err
-		} else if err := commoncmd.WaitInstanceMonitor(ctx, c, t.path, t.Time, errC); err != nil {
+		} else if err := commoncmd.WaitAllInstanceMonitor(ctx, c, t.path, t.Time, errC); err != nil {
+			// Wait until all instance monitors are registered before continuing, otherwise the next orchestration
+			// step may return early due to missing cluster monitors.
 			if errors.Is(err, os.ErrNotExist) {
 				// the daemon is not running.
 			} else {

--- a/core/oxcmd/object_create.go
+++ b/core/oxcmd/object_create.go
@@ -66,7 +66,9 @@ func (t *CmdObjectCreate) Run(kind string) error {
 	if t.Wait || t.Provision {
 		ctx, cancel := context.WithTimeout(context.Background(), t.Time)
 		defer cancel()
-		if err := commoncmd.WaitInstanceMonitor(ctx, t.client, t.path, 0, errC); err != nil {
+		if err := commoncmd.WaitAllInstanceMonitor(ctx, t.client, t.path, 0, errC); err != nil {
+			// Wait until all instance monitors are registered before continuing, otherwise the next orchestration
+			// step may return early due to missing cluster monitors.
 			return err
 		}
 	}

--- a/daemon/encryptconn/main.go
+++ b/daemon/encryptconn/main.go
@@ -127,6 +127,8 @@ func getMessage(r io.Reader) ([]byte, error) {
 	scanner.Buffer(*sharedBuffer, msgMaxSize)
 	scanner.Split(splitFunc)
 	scanner.Scan()
-	b := scanner.Bytes()
+	sharedB := scanner.Bytes()
+	b := make([]byte, len(sharedB))
+	copy(b, sharedB)
 	return b, scanner.Err()
 }

--- a/daemon/imon/orchestration.go
+++ b/daemon/imon/orchestration.go
@@ -188,7 +188,7 @@ func (t *Manager) getOrchestrationEnd() *orchestrationEnd {
 	}
 }
 
-// publishObjectOrchestrationEnd publishes orchestration end message
+// publishObjectOrchestrationEnd publishes the orchestration end message
 func (t *Manager) publishObjectOrchestrationEnd(o *orchestrationEnd, aborted bool) {
 	t.publisher.Pub(&msgbus.ObjectOrchestrationEnd{
 		Node:                  t.localhost,


### PR DESCRIPTION
```
### Description

This pull request addresses the following changes:

- Fixes a timeout error in the `WaitInstanceMonitor` function by introducing a dedicated client, which allows customizable timeouts for better flexibility.
- Enhances error messages in `WaitInstanceMonitor` and `WaitInstanceStatusUpdated` by including elapsed time to improve debugging and provide a clearer context for monitoring issues.

```