### PR TITLE
Fix SCSI key formatting and registration status inconsistencies

### DIFF
--- a/util/scsi/mpath_persist.go
+++ b/util/scsi/mpath_persist.go
@@ -5,10 +5,11 @@ package scsi
 import (
 	"strings"
 
+	"github.com/rs/zerolog"
+
 	"github.com/opensvc/om3/util/command"
 	"github.com/opensvc/om3/util/device"
 	"github.com/opensvc/om3/util/plog"
-	"github.com/rs/zerolog"
 )
 
 type (
@@ -30,7 +31,7 @@ func (t MpathPersistDriver) ReadRegistrations(dev device.T) ([]string, error) {
 	}
 	for _, line := range strings.Split(string(b), "\n") {
 		if strings.HasPrefix(line, "    0x") {
-			l = append(l, line[4:])
+			l = append(l, formatKey(line[4:]))
 		}
 	}
 	return l, nil
@@ -72,7 +73,7 @@ func (t MpathPersistDriver) ReadReservation(dev device.T) (string, error) {
 	}
 	for _, line := range strings.Split(string(b), "\n") {
 		if strings.HasPrefix(line, "   Key = 0x") {
-			return line[9:], nil
+			return formatKey(line[9:]), nil
 		}
 	}
 	return "", nil

--- a/util/scsi/persistent_reservation.go
+++ b/util/scsi/persistent_reservation.go
@@ -49,6 +49,26 @@ func StripPRKey(s string) string {
 	return "0x" + strings.ToLower(strings.TrimLeft(strings.TrimPrefix(s, "0x"), "0"))
 }
 
+// formatKey formats a string key by stripping a leading "0x", truncating it to 16 characters if necessary,
+// and padding it with leading zeroes. The formatted key is returned with a "0x" prefix.
+// It is used to format the reservation or registration key read from device and the
+// configured node scsi key.
+//
+//	"0xa"                   -> "0x000000000000000a"
+//	"0xab"                  -> "0x00000000000000ab"
+//	"0x1234567890123456789" -> "0x1234567890123456"
+//	"0x1234567890123456"    -> "0x1234567890123456"
+func formatKey(s string) string {
+	// Strip leading 0x
+	s = s[2:]
+	if len(s) > 16 {
+		// Truncate to 16 bytes
+		s = s[:16]
+	}
+	// add leading 0x and Pad with 0
+	return fmt.Sprintf("0x%016s", s)
+}
+
 func (t PersistentReservationHandle) countHandledRegistrations(registrations []string) int {
 	n := 0
 	for _, r := range registrations {

--- a/util/scsi/sg_persist.go
+++ b/util/scsi/sg_persist.go
@@ -48,7 +48,7 @@ func (t SGPersistDriver) readRegistrations(dev device.T) ([]string, error) {
 	}
 	for _, line := range strings.Split(string(b), "\n") {
 		if strings.HasPrefix(line, "    0x") {
-			l = append(l, line[4:])
+			l = append(l, formatKey(line[4:]))
 		}
 	}
 	return l, nil
@@ -116,7 +116,7 @@ func (t SGPersistDriver) readReservation(dev device.T) (string, error) {
 	}
 	for _, line := range strings.Split(string(b), "\n") {
 		if strings.HasPrefix(line, "    Key=0x") {
-			return line[8:], nil
+			return formatKey(line[8:]), nil
 		}
 	}
 	return "", nil


### PR DESCRIPTION
### Description

This pull request introduces the `formatKey` utility to ensure consistent SCSI key formatting. The utility applies zero-padding and truncation logic to standardize the keys to a fixed length ("0x" + 16 characters). Updates include:

- Implementing `formatKey` for appropriately formatted read registration or reservation keys.
- Replacing duplicated logic in `mpath_persist`, `persistent_reservation`, and `sg_persist` with the new utility to enhance maintainability and consistency.
- Resolving incorrect instance status representation when reserved by a local host with a key length less than the expected format (16 + 2).

