### PR TITLE
Ensure instance state freshness before enabling monitoring

### DIFF
--- a/daemon/imon/main_cmd.go
+++ b/daemon/imon/main_cmd.go
@@ -249,10 +249,10 @@ func (t *Manager) onMyInstanceStatusUpdated(srcNode string, srcCmd *msgbus.Insta
 		t.instStatus[srcCmd.Node] = srcCmd.Value
 	case instStatus.UpdatedAt.Before(srcCmd.Value.UpdatedAt):
 		// only update if more recent
-		t.log.Debugf("ObjectStatusUpdated %s from InstanceStatusUpdated on %s update instance status", srcNode, srcCmd.Node)
+		t.log.Debugf("ObjectStatusUpdated %s from InstanceStatusUpdated on %s update instance status with avail %s", srcNode, srcCmd.Node, srcCmd.Value.Avail)
 		t.instStatus[srcCmd.Node] = srcCmd.Value
 	default:
-		t.log.Debugf("ObjectStatusUpdated %s from InstanceStatusUpdated on %s skip update instance from obsolete status", srcNode, srcCmd.Node)
+		t.log.Debugf("ObjectStatusUpdated %s from InstanceStatusUpdated on %s skip update instance from obsolete status avail %s", srcNode, srcCmd.Node, srcCmd.Value.Avail)
 	}
 }
 


### PR DESCRIPTION
### Summary

This pull request addresses an issue where monitoring could mistakenly be enabled for an instance despite outdated status data. It introduces a check to verify that the instance `UpdatedAt` timestamp is more recent than the `LocalExpectUpdatedAt` before enabling monitoring. 

Additionally, it improves traceability by adding detailed logging for local instance status changes, including availability, overall status, and frozen state transitions. These enhancements help ensure correct system behavior and facilitate debugging. 
