### PR TITLE
Improve logging for instance or object status updates

### DIFF
--- a/daemon/istat/main.go
+++ b/daemon/istat/main.go
@@ -285,6 +285,9 @@ func (t *T) onInstanceStatusPost(msg *msgbus.InstanceStatusPost) {
 	if prev.Overall != msg.Value.Overall {
 		naming.LogWithPath(t.log, msg.Path).Infof("%s: change overall %s -> %s", s, prev.Overall, msg.Value.Overall)
 	}
+	if prev.Provisioned != msg.Value.Provisioned {
+		naming.LogWithPath(t.log, msg.Path).Infof("%s: change provisioned %s -> %s", s, prev.Provisioned, &msg.Value.Provisioned)
+	}
 	if prev.IsFrozen() != msg.Value.IsFrozen() {
 		naming.LogWithPath(t.log, msg.Path).Infof("%s: change frozen to %v", s, msg.Value.IsFrozen())
 	}

--- a/daemon/omon/main.go
+++ b/daemon/omon/main.go
@@ -355,18 +355,33 @@ func (t *Manager) updateStatus() {
 		}
 
 		t.status.UpInstancesCount = statusAvailCount[status.Up]
+
+		prev := t.status.Avail
 		t.status.Avail = agregateStatus(statusAvailCount)
+		if prev != t.status.Avail {
+			t.log.Infof("change avail from %s -> %s", prev, t.status.Avail)
+		}
+
+		prev = t.status.Overall
 		t.status.Overall = agregateStatus(statusOverallCount)
+		if prev != t.status.Overall {
+			t.log.Infof("change overall from %s -> %s", prev, t.status.Overall)
+		}
 	}
 
 	updateProvisioned := func() {
+		prev := t.status.Provisioned
 		t.status.Provisioned = provisioned.Undef
 		for _, instStatus := range t.instStatus {
 			t.status.Provisioned = t.status.Provisioned.And(instStatus.Provisioned)
 		}
+		if prev != t.status.Provisioned {
+			t.log.Infof("change provisioned from %s -> %s", prev, t.status.Provisioned)
+		}
 	}
 
 	updateFrozen := func() {
+		prev := t.status.Frozen
 		m := map[bool]int{
 			true:  0,
 			false: 0,
@@ -384,6 +399,9 @@ func (t *Manager) updateStatus() {
 			t.status.Frozen = "unfrozen"
 		default:
 			t.status.Frozen = "mixed"
+		}
+		if prev != t.status.Frozen {
+			t.log.Infof("change frozen from %s -> %s", prev, t.status.Frozen)
 		}
 	}
 


### PR DESCRIPTION
Enhance instance status monitoring by adding logs for key attribute transitions:

- Added logging for `avail`, `overall`, `provisioned`, and `frozen` attributes in the `omon` module.
- Improved traceability by logging `provisioned` attribute changes in the `istat` module.

These changes improve observability and debugging capabilities for instance status updates.