### PR TITLE
Reduce log verbosity and update API log level paths

### DIFF
--- a/daemon/daemonapi/lib_middleware.go
+++ b/daemon/daemonapi/lib_middleware.go
@@ -30,10 +30,10 @@ var (
 	// logRequestLevelPerPath defines logRequestMiddleWare log level per path.
 	// The default value is LevelInfo
 	logRequestLevelPerPath = map[string]zerolog.Level{
-		"/metrics":        zerolog.DebugLevel,
-		"/public/openapi": zerolog.DebugLevel,
-		"/public/ui/*":    zerolog.DebugLevel,
-		"/relay/message":  zerolog.DebugLevel,
+		"/metrics":           zerolog.DebugLevel,
+		"/api/openapi":       zerolog.DebugLevel,
+		"/api/docs/*":        zerolog.DebugLevel,
+		"/api/relay/message": zerolog.DebugLevel,
 	}
 )
 

--- a/daemon/daemondata/apply_patch.go
+++ b/daemon/daemondata/apply_patch.go
@@ -76,7 +76,7 @@ func (d *data) applyMsgEvents(msg *hbtype.Msg) error {
 		d.log.Infof(
 			"apply patch skipped %s gen %d (ask full from empty patch) len events: %d gens:%+v eventIDs: %+v hbGens[%s]: %v",
 			remote, msg.Gen[remote], len(msg.Events), d.hbGens, eventIDs, remote, d.hbGens[remote])
-		d.log.Infof("Msg is : %+v", *msg)
+		d.log.Debugf("Msg is : %+v", *msg)
 
 		setNeedFull()
 		return nil


### PR DESCRIPTION

This pull request makes two changes related to logging:

1. Reduces log verbosity when `apply_patch` requests the full dataset, ensuring logs remain concise.
2. Updates `logRequestLevelPerPath` paths to align with the revised API endpoint structure for accurate log level control.
