### PR TITLE
Add container auto-removal option

### DIFF
--- a/daemon/daemonapi/lib_middleware.go
+++ b/daemon/daemonapi/lib_middleware.go
@@ -123,7 +123,6 @@ func RateLimiterWithConfig(parent context.Context) echo.MiddlewareFunc {
 
 func LogMiddleware(parent context.Context) echo.MiddlewareFunc {
 	oLog := logWithFamilyAndAddr(parent)
-	prefix := oLog.Prefix()
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -133,7 +132,7 @@ func LogMiddleware(parent context.Context) echo.MiddlewareFunc {
 				Attr("request_uuid", requestUUID.String()).
 				Attr("request_method", r.Method).
 				Attr("request_path", r.URL.Path).
-				WithPrefix(fmt.Sprintf("%s%s %s: ", prefix, r.Method, r.URL.Path)).
+				AddPrefix(fmt.Sprintf("%s %s: ", r.Method, r.URL.Path)).
 				Level(LogLevel)
 			c.Set("logger", log)
 			c.Set("uuid", requestUUID)

--- a/drivers/rescontainerocibase/main.go
+++ b/drivers/rescontainerocibase/main.go
@@ -584,6 +584,13 @@ func (t *BT) Start(ctx context.Context) error {
 	}
 }
 
+func (t *BT) RemoveContainer(ctx context.Context) error {
+	if t.executer == nil {
+		return t.logMainAction("remove", errors.New("undefined executer"))
+	}
+	return t.executer.Remove(ctx)
+}
+
 func (t *BT) Stop(ctx context.Context) error {
 	name := t.ContainerName()
 	log := t.Log()

--- a/drivers/restaskocibase/keywords.go
+++ b/drivers/restaskocibase/keywords.go
@@ -86,6 +86,14 @@ var (
 			Text:      keywords.NewText(fs, "text/kw/entrypoint"),
 		},
 		{
+			Option:    "rm",
+			Attr:      "Remove",
+			Scopable:  true,
+			Converter: "bool",
+			Example:   "false",
+			Text:      keywords.NewText(fs, "text/kw/rm"),
+		},
+		{
 			Attr:      "Privileged",
 			Converter: "bool",
 			Option:    "privileged",

--- a/drivers/restaskocibase/main.go
+++ b/drivers/restaskocibase/main.go
@@ -76,6 +76,7 @@ type (
 	ContainerTasker interface {
 		Start(context.Context) error
 		Stop(context.Context) error
+		RemoveContainer(context.Context) error
 		ContainerInspectRefresh(context.Context) (rescontainerocibase.Inspecter, error)
 		Signal(context.Context, syscall.Signal) error
 	}
@@ -114,7 +115,7 @@ func (t *T) lockedRun(ctx context.Context) (err error) {
 
 	startErr := container.Start(ctx)
 
-	// TODO: handle rm = true, detach = true ?
+	// TODO: handle detach = true ?
 
 	inspect, err := container.ContainerInspectRefresh(ctx)
 	if err != nil {
@@ -140,6 +141,11 @@ func (t *T) lockedRun(ctx context.Context) (err error) {
 		return err
 	} else if s != status.Up {
 		return fmt.Errorf("command exited with code %d", exitCode)
+	}
+	if t.Remove {
+		if err := container.RemoveContainer(ctx); err != nil {
+			return fmt.Errorf("remove container: %w", err)
+		}
 	}
 	return nil
 }

--- a/drivers/restaskocibase/text/kw/rm
+++ b/drivers/restaskocibase/text/kw/rm
@@ -1,0 +1,1 @@
+If rm=true, the container task instance is removed after successfully run.


### PR DESCRIPTION
This pull request introduces the following changes:

- Added container auto-removal functionality after task completion:
  - Introduced `RemoveContainer` method in the `ContainerTasker` interface.
  - Added `rm` keyword to enable conditional container removal.
  - Updated task execution logic to remove containers when `rm=true`.

- Simplified the `LogMiddleware` to improve code readability as per PR review feedback.
