### PR TITLE
Improve global expectation handling and synchronization  

### DIFF
--- a/daemon/imon/converge_global_expect.go
+++ b/daemon/imon/converge_global_expect.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/opensvc/om3/v3/core/instance"
+	"github.com/opensvc/om3/v3/util/file"
 )
 
 // convergeGlobalExpectFromRemote set global expect from most recent global expect value
@@ -50,6 +51,20 @@ func (t *Manager) convergeGlobalExpectFromRemote() {
 
 func (t *Manager) isConvergedGlobalExpect() bool {
 	localUpdated := t.state.GlobalExpectUpdatedAt
+
+	// defines the expected instance monitors from scope nodes:
+	// If local instance has been created recently, it will take time to:
+	// 1- propagate the instance config file on peers
+	// 2- peer imon startup, push its state
+	// 3- peer imon state is propagated to local imon.
+	expectedInstanceMonitor := make(map[string]struct{})
+	for _, n := range t.scopeNodes {
+		if n == t.localhost {
+			continue
+		}
+		expectedInstanceMonitor[n] = struct{}{}
+	}
+
 	for s, v := range t.instMonitor {
 		if s == t.localhost {
 			err := fmt.Errorf("bug: isConvergedGlobalExpect detect unexpected localhost in internal instance monitor cache keys")
@@ -59,6 +74,38 @@ func (t *Manager) isConvergedGlobalExpect() bool {
 		if localUpdated.After(v.GlobalExpectUpdatedAt) {
 			t.log.Tracef("wait GlobalExpect propagation on %s", s)
 			return false
+		}
+		// we have a converged GlobalExpect (we don't expect any more propagation from this peer node)
+		delete(expectedInstanceMonitor, s)
+	}
+	if len(expectedInstanceMonitor) > 0 {
+		// expected peer instance monitors are still missing
+		switch t.state.GlobalExpect {
+		case instance.MonitorGlobalExpectPurged, instance.MonitorGlobalExpectDeleted:
+			// purge or deletion orchestration, we can ignore missing peer monitor states,
+			// peer instances may have been already deleted.
+		default:
+			for n := range expectedInstanceMonitor {
+				if _, ok := t.nodeMonitor[n]; ok {
+					t.log.Tracef("wait for initial GlobalExpect propagation on %s", n)
+					return false
+				}
+			}
+		}
+	}
+	if t.state.GlobalExpect != instance.MonitorGlobalExpectNone && t.state.GlobalExpect != instance.MonitorGlobalExpectInit {
+		if t.state.GlobalExpectUpdatedAt.Sub(t.instConfig.UpdatedAt) < time.Second {
+			// The instance config has been modified within the same second of the global expectation update.
+			// Take time to verify if we have the last instance config:
+			//     t.instConfig.UpdatedAt versus config file mod time
+			cfgFileModtime := file.ModTime(t.path.ConfigFile())
+			if cfgFileModtime.IsZero() {
+				return false
+			}
+			if cfgFileModtime.After(t.instConfig.UpdatedAt) {
+				t.log.Tracef("wait GlobalExpect propagation delayed: config file has been updated")
+				return false
+			}
 		}
 	}
 	return true

--- a/daemon/imon/main.go
+++ b/daemon/imon/main.go
@@ -360,6 +360,12 @@ func (t *Manager) worker(initialNodes []string) {
 		t.instStatus[n] = *v
 	}
 
+	// force retrieval of possible lost global expectation from the peer
+	// instance monitor cache.
+	// This is usually checked on InstanceMonitorUpdated, but
+	// perhaps such events have been published before the subscription is running.
+	t.convergeGlobalExpectFromRemote()
+
 	t.delayTimer = time.NewTimer(time.Second)
 	if !t.delayTimer.Stop() {
 		<-t.delayTimer.C


### PR DESCRIPTION
### Description of Changes  
- Enhanced logic for global expectation convergence by adding checks for delayed propagation and safeguards for instance configuration accuracy.  
- Ensured global expectations are fetched from peers during startup to minimize the risk of loss.  
- Verified instance configuration via modified config file timestamps.  

### Details  
- **Global Expectation Updates:** Improved handling and convergence logic for better synchronization.  
- **Startup Synchronization:** Added mechanisms to fetch pending global expectations from peer nodes.  
- **Configuration Accuracy:** Introduced safeguards and validation strategies for instance configurations.  

### reproducer: loop on following  shell
    #!/bin/bash
    
    set -e
    set -x
    OSVC_BR1=br-prd
    SVC=c28svc11
    om $SVC create --wait
    om $SVC config update --set ip#0.ipdev=${OSVC_BR1} --set ip#0.ipname=$SVC --set ip#0.shared=true
    om $SVC config update --set disk#1.type=loop --set disk#1.file=/{env.pool1name}.loopfile --set disk#1.size=100M --set disk#1.standby=true --set env.pool1name=data1pool$SVC
    om $SVC config update --set disk#2.type=loop --set disk#2.file=/{env.pool2name}.loopfile --set disk#2.size=100M --set disk#2.standby=true --set env.pool2name=data2pool$SVC
    om $SVC config update --set disk#3.type=loop --set disk#3.file=/{env.pool3name}.loopfile --set disk#3.size=100M --set disk#3.standby=true --set env.pool3name=localpool$SVC
    om $SVC config update --set disk#5.type=zpool --set disk#5.name={env.pool1name} --set disk#5.vdev="{disk#1.file}" --set disk#5.standby=true --set disk#5.create_options="-O acltype=posixacl -O xattr=sa -O compression=off -O normalization=formD -O mountpoint=legacy -O canmount=noauto -O devices=on -O exec=on -O setuid=on"
    om $SVC config update --set disk#6.type=zpool --set disk#6.name={env.pool2name} --set disk#6.vdev="{disk#2.file}" --set disk#6.standby=true --set disk#6.create_options="-O acltype=posixacl -O xattr=sa -O compression=off -O normalization=formD -O mountpoint=legacy -O canmount=noauto -O devices=on -O exec=on -O setuid=on"
    om $SVC config update --set disk#7.type=zpool --set disk#7.name={env.pool3name} --set disk#7.vdev="{disk#3.file}" --set disk#7.standby=true --set disk#7.create_options="-O acltype=posixacl -O xattr=sa -O compression=off -O normalization=formD -O mountpoint=legacy -O canmount=noauto -O devices=on -O exec=on -O setuid=on"
    om $SVC config update --set fs#1.dev={env.pool1name}/fs1 --set fs#1.mnt=/srv/{svcname}/fs1 --set fs#1.type=zfs --set fs#1.mnt_opt="rw,xattr,acl" --set fs#1.shared=true --set fs#1.user=root --set fs#1.group=0 --set fs#1.perm=755
    om $SVC config update --set fs#2.dev={env.pool1name}/fs2 --set fs#2.mnt=/srv/{svcname}/fs2 --set fs#2.type=zfs --set fs#2.mnt_opt="rw,xattr,acl" --set fs#2.shared=true
    om $SVC config update --set DEFAULT.nodes={clusternodes}
    om $SVC provision --wait
    om $SVC purge --wait
