### PR TITLE
[collector] Support for configurable status wait and ping interval

### DIFF
--- a/core/collector/config.go
+++ b/core/collector/config.go
@@ -7,10 +7,12 @@ import (
 
 type (
 	Config struct {
-		FeederUrl string        `json:"feeder_url"`
-		ServerUrl string        `json:"server_url"`
-		Timeout   time.Duration `json:"timeout"`
-		Insecure  bool          `json:"insecure"`
+		FeederUrl    string        `json:"feeder_url"`
+		ServerUrl    string        `json:"server_url"`
+		Timeout      time.Duration `json:"timeout"`
+		Insecure     bool          `json:"insecure"`
+		PingInterval time.Duration `json:"ping_interval"`
+		StatusDelay  time.Duration `json:"status_delay"`
 
 		// Hidden fields
 		Password string `json:"-"`

--- a/core/keywords/keywords.go
+++ b/core/keywords/keywords.go
@@ -175,6 +175,13 @@ func (t *Keyword) Name() string {
 	return t.Attr
 }
 
+func (t *Keyword) String() string {
+	if t.Section == "" {
+		return "DEFAULT." + t.Option
+	}
+	return t.Section + "." + t.Option
+}
+
 func (t Store) Len() int {
 	return len(t)
 }

--- a/core/object/node_collector.go
+++ b/core/object/node_collector.go
@@ -25,6 +25,8 @@ type (
 		timeout      *time.Duration
 		insecure     bool
 		uuid         string
+		pingInterval *time.Duration
+		statusDelay  *time.Duration
 	}
 
 	CollectorProblem struct {
@@ -60,6 +62,8 @@ func (t *Node) CollectorRawConfig() *CollectorConfigRaw {
 		serverUrl:    cfg.GetString(key.Parse("node.collector_server")),
 		timeout:      cfg.GetDuration(key.Parse("node.collector_timeout")),
 		insecure:     cfg.GetBool(key.Parse("node.dbinsecure")),
+		pingInterval: cfg.GetDuration(key.Parse(kwNodeCollectorPingInterval.String())),
+		statusDelay:  cfg.GetDuration(key.Parse(kwNodeCollectorStatusDelay.String())),
 
 		// uuid is loaded from node.conf
 		uuid: t.Config().GetString(key.Parse("node.uuid")),
@@ -91,16 +95,24 @@ func (t *CollectorConfigRaw) ServerUrl() string {
 }
 
 func (t *CollectorConfigRaw) AsConfig() *collector.Config {
-	var timeout time.Duration
+	var timeout, pingInterval, statusDelay time.Duration
 	if t.timeout != nil {
 		timeout = *t.timeout
 	}
+	if t.pingInterval != nil {
+		pingInterval = *t.pingInterval
+	}
+	if t.statusDelay != nil {
+		statusDelay = *t.statusDelay
+	}
 	return &collector.Config{
-		FeederUrl: t.FeederUrl(),
-		ServerUrl: t.ServerUrl(),
-		Timeout:   timeout,
-		Insecure:  t.insecure,
-		Password:  t.uuid,
+		FeederUrl:    t.FeederUrl(),
+		ServerUrl:    t.ServerUrl(),
+		Timeout:      timeout,
+		Insecure:     t.insecure,
+		Password:     t.uuid,
+		PingInterval: pingInterval,
+		StatusDelay:  statusDelay,
 	}
 }
 

--- a/core/object/node_keywords.go
+++ b/core/object/node_keywords.go
@@ -380,6 +380,24 @@ var (
 		Text:        keywords.NewText(fs, "text/kw/node/node.collector_feeder"),
 		DefaultText: keywords.NewText(fs, "text/kw/node/node.collector_feeder.default"),
 	}
+	kwNodeCollectorPingInterval = keywords.Keyword{
+		Example:   "120s",
+		Option:    "collector_ping_interval",
+		Aliases:   []string{"db_min_ping_interval"},
+		Section:   "node",
+		Converter: "duration",
+		Default:   "60s",
+		Text:      keywords.NewText(fs, "text/kw/node/node.collector_ping_interval"),
+	}
+	kwNodeCollectorStatusDelay = keywords.Keyword{
+		Example:   "30s",
+		Option:    "collector_status_delay",
+		Aliases:   []string{"db_min_update_interval"},
+		Section:   "node",
+		Converter: "duration",
+		Default:   "10s",
+		Text:      keywords.NewText(fs, "text/kw/node/node.collector_status_delay"),
+	}
 	kwNodeCollectorTimeout = keywords.Keyword{
 		Option:    "collector_timeout",
 		Section:   "node",
@@ -1724,6 +1742,8 @@ var (
 		&kwNodeCollector,
 		&kwNodeCollectorServer,
 		&kwNodeCollectorFeeder,
+		&kwNodeCollectorPingInterval,
+		&kwNodeCollectorStatusDelay,
 		&kwNodeCollectorTimeout,
 		&kwNodeBranch,
 		&kwNodeRepo,

--- a/core/object/text/kw/node/node.collector_ping_interval
+++ b/core/object/text/kw/node/node.collector_ping_interval
@@ -1,0 +1,4 @@
+Set the minimum interval between 2 push alive status to collector.
+It is called when there are no daemon status changes, but we want
+to send alive status to collector.
+Minimum value: 60s

--- a/core/object/text/kw/node/node.collector_status_delay
+++ b/core/object/text/kw/node/node.collector_status_delay
@@ -1,0 +1,2 @@
+Set the minimum delay before next push daemon status changes to collector.
+Minimum value: 10s

--- a/daemon/collector/main.go
+++ b/daemon/collector/main.go
@@ -4,6 +4,7 @@ package collector
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -44,12 +45,17 @@ type (
 
 		postTicker *time.Ticker
 
-		// postPingOrStatusAt is the timestamp of latest post daemon ping, status.
-		postPingOrStatusAt time.Time
+		// feedStatusAt is the timestamp of latest post daemon status.
+		feedStatusAt time.Time
 
-		// postPingDelay is the minimum delay to wait after postPingOrStatusAt
-		// for the next post daemon ping.
-		postPingDelay time.Duration
+		// feedPingOrStatusAt is the timestamp of latest post daemon ping, or status.
+		feedPingOrStatusAt time.Time
+
+		// pingInterval specifies the interval at which the daemon sends a ping (when no changes are detected).
+		pingInterval time.Duration
+
+		// statusDelay specifies the delay to wait before sending the daemon status when changes are detected.
+		statusDelay time.Duration
 
 		// previousUpdatedAt is the timestamp of the last successfully data sent to
 		// collector. It is used by the  collector to detect changes chain breaks.
@@ -164,6 +170,9 @@ type (
 const (
 	headerDaemonChange      = "XDaemonChange"
 	headerPreviousUpdatedAt = "XPreviousUpdatedAt"
+
+	minFeedStatusDelay  = 10 * time.Second
+	minFeedPingInterval = 60 * time.Second
 )
 
 var (
@@ -187,13 +196,11 @@ var (
 
 func New(ctx context.Context, subQS pubsub.QueueSizer, opts ...funcopt.O) *T {
 	now := time.Now()
-	postPingOrStatusMinInterval := 10 * time.Second
 	t := &T{
-		log:           plog.NewDefaultLogger().WithPrefix("daemon: collector: ").Attr("pkg", "daemon/collector"),
-		localhost:     hostname.Hostname(),
-		postPingDelay: postPingOrStatusMinInterval,
-		clusterData:   daemondata.FromContext(ctx),
-		subQS:         subQS,
+		log:         plog.NewDefaultLogger().WithPrefix("daemon: collector: ").Attr("pkg", "daemon/collector"),
+		localhost:   hostname.Hostname(),
+		clusterData: daemondata.FromContext(ctx),
+		subQS:       subQS,
 		status: daemonsubsystem.Collector{
 			Status: daemonsubsystem.Status{
 				CreatedAt: now,
@@ -203,8 +210,6 @@ func New(ctx context.Context, subQS pubsub.QueueSizer, opts ...funcopt.O) *T {
 			Url: "",
 		},
 		version: "3.0.0",
-
-		objectConfigToSendMinDelay: 2 * postPingOrStatusMinInterval,
 	}
 	if err := funcopt.Apply(t, opts...); err != nil {
 		t.log.Errorf("init: %s", err)
@@ -265,11 +270,18 @@ func (t *T) Start(ctx context.Context) error {
 
 	t.wg.Add(1)
 
-	initialNodeConfig := node.ConfigData.GetByNode(t.localhost)
-
 	go func(errC chan<- error) {
 		defer t.wg.Done()
-		if err := t.setNodeFeedClient(initialNodeConfig.Collector); err != nil {
+		initialNodeConfig := node.ConfigData.GetByNode(t.localhost)
+		if initialNodeConfig == nil {
+			errC <- fmt.Errorf("unexpected nil node config data")
+			return
+		}
+		cfg := initialNodeConfig.Collector
+
+		t.setThrottle(cfg)
+
+		if err := t.setNodeFeedClient(cfg); err != nil {
 			t.log.Infof("the collector routine is dormant: %s", err)
 		} else {
 			t.log.Infof("feeding %s", t.feedClient)
@@ -277,7 +289,7 @@ func (t *T) Start(ctx context.Context) error {
 			t.feedPinger.Start(t.ctx, FeedPingerInterval)
 			defer t.feedPinger.Stop()
 		}
-		if err := t.setupRequester(initialNodeConfig.Collector); err != nil {
+		if err := t.setupRequester(cfg); err != nil {
 			t.log.Errorf("can't setup requester: %s", err)
 		}
 		errC <- nil
@@ -498,4 +510,28 @@ func (t *T) publishOnChange(state string) {
 		t.status.UpdatedAt = time.Now()
 		t.publish()
 	}
+}
+
+// setThrottle adjusts the ping interval and status delay based on the provided configuration
+// or default values.
+func (t *T) setThrottle(cfg *collector.Config) {
+	var delay, interval time.Duration
+	if cfg == nil {
+		interval = minFeedPingInterval
+		delay = minFeedStatusDelay
+	} else {
+		interval = cfg.PingInterval
+		delay = cfg.StatusDelay
+	}
+	delay = max(delay, minFeedStatusDelay)
+	interval = max(interval, minFeedPingInterval)
+	if t.pingInterval != interval {
+		t.log.Infof("feeder ping interval: %s", interval)
+		t.pingInterval = interval
+	}
+	if t.statusDelay != delay {
+		t.log.Infof("feeder status delay: %s", delay)
+		t.statusDelay = delay
+	}
+	t.objectConfigToSendMinDelay = 2 * min(t.pingInterval, t.statusDelay)
 }

--- a/daemon/collector/on_events.go
+++ b/daemon/collector/on_events.go
@@ -123,11 +123,13 @@ func (t *T) onNodeConfigUpdated(c *msgbus.NodeConfigUpdated) {
 		t.log.Infof("disable collector clients")
 		collector.Alive.Store(false)
 	}
-	err := t.setNodeFeedClient(c.Value.Collector)
+	cfg := c.Value.Collector
+	t.setThrottle(cfg)
+	err := t.setNodeFeedClient(cfg)
 	if t.feedPinger != nil {
 		t.feedPinger.Stop()
 	}
-	if err := t.setupRequester(c.Value.Collector); err != nil {
+	if err := t.setupRequester(cfg); err != nil {
 		if !errors.Is(err, collector.ErrConfig) {
 			t.log.Errorf("can't setup requester: %s", err)
 		}

--- a/daemon/collector/post_feed_daemon_status_and_ping.go
+++ b/daemon/collector/post_feed_daemon_status_and_ping.go
@@ -61,10 +61,7 @@ func (t *T) sendCollectorDataLegacy() error {
 	if t.hasDaemonStatusChange() {
 		return t.postStatus()
 	} else {
-		if time.Now().After(t.postPingOrStatusAt.Add(t.postPingDelay)) {
-			return t.postPing()
-		}
-		return nil
+		return t.postPing()
 	}
 }
 
@@ -99,7 +96,12 @@ func (t *T) postPing() error {
 		path   = oc3path.FeedDaemonPing
 
 		ioReader io.Reader
+		now      = time.Now()
 	)
+	if now.Sub(t.feedPingOrStatusAt) < t.pingInterval {
+		t.log.Tracef("postPing throttled")
+		return nil
+	}
 
 	body := *t.postPingBody()
 	if b, err := json.Marshal(body); err != nil {
@@ -108,7 +110,6 @@ func (t *T) postPing() error {
 		ioReader = bytes.NewReader(b)
 	}
 	t.log.Tracef("postFeedDaemonPing: %v", body)
-	now := time.Now()
 
 	ctx, cancel := context.WithTimeout(t.ctx, defaultPostMaxDuration)
 	defer cancel()
@@ -123,7 +124,7 @@ func (t *T) postPing() error {
 	if err != nil {
 		return err
 	}
-	t.postPingOrStatusAt = time.Now()
+	t.feedPingOrStatusAt = time.Now()
 	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
@@ -230,6 +231,12 @@ func (t *T) postStatus() error {
 		t.dropChanges()
 		return nil
 	}
+	now := time.Now()
+	if !t.feedStatusAt.IsZero() && now.Sub(t.feedStatusAt) < t.statusDelay {
+		t.log.Tracef("postStatus throttled")
+		return nil
+	}
+
 	var (
 		req      *http.Request
 		resp     *http.Response
@@ -239,7 +246,6 @@ func (t *T) postStatus() error {
 
 		path = oc3path.FeedDaemonStatus
 	)
-	now := time.Now()
 	body := postFeedDaemonStatus{
 		PreviousUpdatedAt: t.previousUpdatedAt,
 		UpdatedAt:         now,
@@ -271,7 +277,8 @@ func (t *T) postStatus() error {
 	if err != nil {
 		return fmt.Errorf("%s %s: %w", method, path, err)
 	}
-	t.postPingOrStatusAt = time.Now()
+	t.feedStatusAt = time.Now()
+	t.feedPingOrStatusAt = t.feedStatusAt
 	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
@@ -363,7 +370,7 @@ func (t *T) objectConfigToSendFromBody(r io.Reader) (added []naming.Path, err er
 			if sent, ok := t.objectConfigSent[p]; ok {
 				if time.Now().Before(sent.SentAt.Add(t.objectConfigToSendMinDelay)) {
 					toAdd = false
-					t.log.Tracef("delay need instance config send %s", p)
+					t.log.Tracef("throttled instance config send %s", p)
 				}
 			}
 			if toAdd {


### PR DESCRIPTION
### Summary

This pull request introduces the following changes:
- Adds support for configurable `pingInterval` and `statusDelay` in the node collector, allowing dynamic and throttled status handling.
- Implements a `String` method for keywords to provide a formatted and readable representation.
