### PR TITLE
Update 'losetup' parsing and fix ZFS mount options

### DIFF
--- a/drivers/resfszfs/main.go
+++ b/drivers/resfszfs/main.go
@@ -202,8 +202,7 @@ func (t *T) mountLegacy() error {
 	a.Append("-t", "zfs")
 	mountOptions := t.mountOptions()
 	if len(mountOptions) > 0 {
-		a.Append("-o")
-		a.Append(t.mountOptions()...)
+		a.Append("-o", strings.Join(mountOptions, ","))
 	}
 	a.Append(t.Device, t.MountPoint)
 	cmd := command.New(

--- a/util/loop/main.go
+++ b/util/loop/main.go
@@ -2,8 +2,8 @@ package loop
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/opensvc/fcntllock"
@@ -31,14 +31,8 @@ type (
 	}
 
 	InfoEntry struct {
-		Name      string `json:"name"`      // "/dev/loop1"
-		BackFile  string `json:"back-file"` // "/var/lib/snapd/snaps/gnome-3-34-1804_66.snap"
-		SizeLimit any    `json:"sizelimit"` // 0, "0"
-		Offset    any    `json:"offset"`    // 0, "0"
-		AutoClear any    `json:"autoclear"` // true, 0
-		ReadOnly  any    `json:"ro"`        // true, 0
-		DirectIO  any    `json:"dio"`       // false, 0
-		LogSec    any    `json:"log-sec"`   // 512, "512"
+		Name     string `json:"name"`      // "/dev/loop1"
+		BackFile string `json:"back-file"` // "/var/lib/snapd/snaps/gnome-3-34-1804_66.snap"
 	}
 
 	InfoEntries []InfoEntry
@@ -94,14 +88,14 @@ func (t T) Get(ctx context.Context, name string) (*InfoEntry, error) {
 
 func (t T) Data(ctx context.Context) (InfoEntries, error) {
 	var (
-		out []byte
-		err error
+		out     []byte
+		err     error
+		entries InfoEntries
 	)
-	data := Info{}
 	cmd := command.New(
 		command.WithContext(ctx),
 		command.WithName(losetup),
-		command.WithVarArgs("-J"),
+		command.WithVarArgs("-O", "NAME,BACK-FILE"), // The -J and -n options are not supported by losetup on RHEL 7.
 		command.WithLogger(t.log),
 		command.WithCommandLogLevel(zerolog.TraceLevel),
 		command.WithStdoutLogLevel(zerolog.TraceLevel),
@@ -114,10 +108,25 @@ func (t T) Data(ctx context.Context) (InfoEntries, error) {
 	if len(out) == 0 {
 		return InfoEntries{}, nil
 	}
-	if err = json.Unmarshal(out, &data); err != nil {
-		return nil, err
+	/*
+		Output to parse: losetup -O NAME,BACK-FILE
+		NAME       BACK-FILE
+		/dev/loop0 /tmp/loopfile0 (deleted)
+		/dev/loop1 /tmp/loopfile1
+	*/
+	for line := range strings.Lines(string(out)) {
+		l := strings.Fields(line)
+		if len(l) >= 2 {
+			if l[0] == "NAME" {
+				continue
+			}
+			entries = append(entries, InfoEntry{
+				Name:     l[0],
+				BackFile: l[1],
+			})
+		}
 	}
-	return data.LoopDevices, nil
+	return entries, nil
 }
 
 func (t T) Add(ctx context.Context, filePath string) error {
@@ -190,9 +199,6 @@ func (t InfoEntries) Name(s string) *InfoEntry {
 func (t InfoEntries) File(s string) *InfoEntry {
 	for _, i := range t {
 		if i.BackFile == s {
-			return &i
-		}
-		if i.BackFile == s+" (deleted)" {
 			return &i
 		}
 	}

--- a/util/loop/main.go
+++ b/util/loop/main.go
@@ -11,9 +11,9 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/opensvc/om3/v3/util/command"
-	"github.com/opensvc/om3/v3/util/sessioncache"
 	"github.com/opensvc/om3/v3/util/funcopt"
 	"github.com/opensvc/om3/v3/util/plog"
+	"github.com/opensvc/om3/v3/util/sessioncache"
 	"github.com/opensvc/om3/v3/util/udevadm"
 )
 
@@ -25,19 +25,22 @@ type (
 	T struct {
 		log *plog.Logger
 	}
+
 	Info struct {
 		LoopDevices []InfoEntry `json:"loopdevices"`
 	}
+
 	InfoEntry struct {
 		Name      string `json:"name"`      // "/dev/loop1"
-		SizeLimit int64  `json:"sizelimit"` // 0
-		Offset    int64  `json:"offset"`    // 0
-		AutoClear bool   `json:"autoclear"` // true
-		ReadOnly  bool   `json:"ro"`        // true
 		BackFile  string `json:"back-file"` // "/var/lib/snapd/snaps/gnome-3-34-1804_66.snap"
-		DirectIO  bool   `json:"dio"`       // false
-		LogSec    int64  `json:"log-sec"`   // 512
+		SizeLimit any    `json:"sizelimit"` // 0, "0"
+		Offset    any    `json:"offset"`    // 0, "0"
+		AutoClear any    `json:"autoclear"` // true, 0
+		ReadOnly  any    `json:"ro"`        // true, 0
+		DirectIO  any    `json:"dio"`       // false, 0
+		LogSec    any    `json:"log-sec"`   // 512, "512"
 	}
+
 	InfoEntries []InfoEntry
 )
 


### PR DESCRIPTION
### Summary of Changes

- Updated the `losetup` command to replace `-J` with `-O NAME,BACK-FILE` for improved compatibility with older RHEL versions.
- Refactored the parsing logic by removing `json.Unmarshal` and implementing a manual parsing approach.
- Simplified `InfoEntry` structure and changed field types to `any` to handle mixed value formats.
- Fixed `mountLegacy` options for ZFS mounts, correcting option syntax to properly separate values.