### PR TITLE
Template: support 'keys' func, Events: support 'NodeStatusArbitratorsUpdated' replay

### DIFF
--- a/core/commoncmd/daemon_events.go
+++ b/core/commoncmd/daemon_events.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opensvc/om3/v3/daemon/msgbus"
 	"github.com/opensvc/om3/v3/util/flatten"
 	"github.com/opensvc/om3/v3/util/pubsub"
+	"github.com/opensvc/om3/v3/util/xmap"
 )
 
 type (
@@ -183,6 +184,7 @@ func (t *CmdDaemonEvents) DoNodes() error {
 			"stringsContains":  strings.Contains,
 			"stringsHasPrefix": strings.HasPrefix,
 			"stringsHasSuffix": strings.HasSuffix,
+			"keys":             xmap.Keys,
 		}
 
 		evTemplate.Funcs(funcMap)

--- a/core/commoncmd/text/node-events/flag/template
+++ b/core/commoncmd/text/node-events/flag/template
@@ -10,6 +10,8 @@ The template syntax follows the go template standard, with a few custom extra fu
 
 * `hasInstanceLabel(labels []pubsub.Label, expected ...string) bool`
 
+* `keys(map) []string`
+
 * `passSet(s string, b bool)`
 
   Add s to passed if b else remove s from passed.

--- a/core/output/template.go
+++ b/core/output/template.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opensvc/om3/v3/core/naming"
 	"github.com/opensvc/om3/v3/core/resourceid"
 	"github.com/opensvc/om3/v3/util/unstructured"
+	"github.com/opensvc/om3/v3/util/xmap"
 )
 
 func (t Renderer) renderTemplate(options string) (string, error) {
@@ -144,6 +145,7 @@ func (t Renderer) renderTemplate(options string) (string, error) {
 		"fnMatch":      fnMatch,
 		"hasPrefix":    hasPrefix,
 		"hasSuffix":    hasSuffix,
+		"keys":         xmap.Keys,
 		"objKind":      objKind,
 		"objName":      objName,
 		"objNamespace": objNamespace,

--- a/core/output/template.go
+++ b/core/output/template.go
@@ -16,6 +16,19 @@ import (
 )
 
 func (t Renderer) renderTemplate(options string) (string, error) {
+	contains := func(slice any, entry any) (bool, error) {
+		if s, ok := slice.([]string); ok {
+			if e, ok := entry.(string); ok {
+				return slices.Contains(s, e), nil
+			}
+		}
+		if s, ok := slice.([]int); ok {
+			if e, ok := entry.(int); ok {
+				return slices.Contains(s, e), nil
+			}
+		}
+		return false, nil
+	}
 	drvName := func(i any) string {
 		var drvID driver.ID
 		switch a := i.(type) {
@@ -42,31 +55,14 @@ func (t Renderer) renderTemplate(options string) (string, error) {
 		}
 		return drvID.Group.String()
 	}
-	resName := func(i any) string {
-		var rid *resourceid.T
-		switch a := i.(type) {
-		case *resourceid.T:
-			rid = a
-		case string:
-			rid, _ = resourceid.Parse(a)
-		}
-		if rid == nil {
-			return ""
-		}
-		return rid.Index()
+	fnMatch := func(pattern, s string) bool {
+		return fnmatch.Match(pattern, s, 0)
 	}
-	resGroup := func(i any) string {
-		var rid *resourceid.T
-		switch a := i.(type) {
-		case *resourceid.T:
-			rid = a
-		case string:
-			rid, _ = resourceid.Parse(a)
-		}
-		if rid == nil {
-			return ""
-		}
-		return rid.DriverGroup().String()
+	hasPrefix := func(s, prefix string) bool {
+		return strings.HasPrefix(s, prefix)
+	}
+	hasSuffix := func(s, suffix string) bool {
+		return strings.HasSuffix(s, suffix)
 	}
 	objKind := func(i any) string {
 		var path naming.Path
@@ -107,28 +103,6 @@ func (t Renderer) renderTemplate(options string) (string, error) {
 		}
 		return path.Namespace
 	}
-	hasPrefix := func(s, prefix string) bool {
-		return strings.HasPrefix(s, prefix)
-	}
-	hasSuffix := func(s, suffix string) bool {
-		return strings.HasSuffix(s, suffix)
-	}
-	contains := func(slice any, entry any) (bool, error) {
-		if s, ok := slice.([]string); ok {
-			if e, ok := entry.(string); ok {
-				return slices.Contains(s, e), nil
-			}
-		}
-		if s, ok := slice.([]int); ok {
-			if e, ok := entry.(int); ok {
-				return slices.Contains(s, e), nil
-			}
-		}
-		return false, nil
-	}
-	fnMatch := func(pattern, s string) bool {
-		return fnmatch.Match(pattern, s, 0)
-	}
 	reMatch := func(pattern, s string) (bool, error) {
 		r, err := regexp.Compile(pattern)
 		if err != nil {
@@ -137,19 +111,45 @@ func (t Renderer) renderTemplate(options string) (string, error) {
 
 		return r.MatchString(s), nil
 	}
+	resGroup := func(i any) string {
+		var rid *resourceid.T
+		switch a := i.(type) {
+		case *resourceid.T:
+			rid = a
+		case string:
+			rid, _ = resourceid.Parse(a)
+		}
+		if rid == nil {
+			return ""
+		}
+		return rid.DriverGroup().String()
+	}
+	resName := func(i any) string {
+		var rid *resourceid.T
+		switch a := i.(type) {
+		case *resourceid.T:
+			rid = a
+		case string:
+			rid, _ = resourceid.Parse(a)
+		}
+		if rid == nil {
+			return ""
+		}
+		return rid.Index()
+	}
 	tmpl := template.New("output").Funcs(template.FuncMap{
+		"contains":     contains,
 		"drvName":      drvName,
 		"drvGroup":     drvGroup,
-		"resName":      resName,
-		"resGroup":     resGroup,
+		"fnMatch":      fnMatch,
+		"hasPrefix":    hasPrefix,
+		"hasSuffix":    hasSuffix,
 		"objKind":      objKind,
 		"objName":      objName,
 		"objNamespace": objNamespace,
-		"hasPrefix":    hasPrefix,
-		"hasSuffix":    hasSuffix,
-		"contains":     contains,
 		"reMatch":      reMatch,
-		"fnMatch":      fnMatch,
+		"resGroup":     resGroup,
+		"resName":      resName,
 	})
 	tmpl, err := tmpl.Parse(options)
 	if err != nil {

--- a/daemon/msgbus/event_cache.go
+++ b/daemon/msgbus/event_cache.go
@@ -52,6 +52,8 @@ func (data *ClusterData) ExtractEvents(m any, labels pubsub.Labels) ([]any, erro
 		return data.nodeStale(labels)
 	case *NodeStatusUpdated:
 		return data.nodeStatusUpdated(labels)
+	case *NodeStatusArbitratorsUpdated:
+		return data.nodeStatusArbitratorsUpdated(labels)
 	}
 	return nil, nil
 }

--- a/daemon/msgbus/node_status.go
+++ b/daemon/msgbus/node_status.go
@@ -48,3 +48,37 @@ func (data *ClusterData) nodeStatusUpdated(labels pubsub.Labels) ([]any, error) 
 	}
 	return l, nil
 }
+
+func (data *ClusterData) nodeStatusArbitratorsUpdated(labels pubsub.Labels) ([]any, error) {
+	l := make([]any, 0)
+	if nodename := labels["node"]; nodename != "" {
+		if nodeData, ok := data.Cluster.Node[nodename]; ok {
+			m := make(map[string]node.ArbitratorStatus)
+			for k, v := range nodeData.Status.Arbitrators {
+				m[k] = v
+			}
+			l = append(l, &NodeStatusArbitratorsUpdated{
+				Msg: pubsub.Msg{
+					Labels: pubsub.NewLabels("node", nodename, "from", "cache"),
+				},
+				Node:  nodename,
+				Value: m,
+			})
+		}
+	} else {
+		for nodename, nodeData := range data.Cluster.Node {
+			m := make(map[string]node.ArbitratorStatus)
+			for k, v := range nodeData.Status.Arbitrators {
+				m[k] = v
+			}
+			l = append(l, &NodeStatusArbitratorsUpdated{
+				Msg: pubsub.Msg{
+					Labels: pubsub.NewLabels("node", nodename, "from", "cache"),
+				},
+				Node:  nodename,
+				Value: m,
+			})
+		}
+	}
+	return l, nil
+}


### PR DESCRIPTION
### Description

This pull request introduces two main changes:
1. Adds support for the `keys` function in templates, enhancing flexibility for accessing map keys during template rendering.
2. Adds support for replaying the `NodeStatusArbitratorsUpdated` event in the events subsystem.

It also includes a refactor of function ordering and `template.FuncMap` to improve code readability and maintainability.
