### PR TITLE
Fix context handling and resolve goroutine leaks when hb.rx or hb.tx are stopped

### DIFF
--- a/core/hbtype/main.go
+++ b/core/hbtype/main.go
@@ -2,6 +2,7 @@
 package hbtype
 
 import (
+	"context"
 	"time"
 
 	"github.com/opensvc/om3/v3/core/event"
@@ -31,6 +32,9 @@ type (
 	Transmitter interface {
 		IDStopper
 		Start(cmdC chan<- interface{}, dataC <-chan []byte) error
+
+		// Ctx returns the context of the running hb driver
+		Ctx() context.Context
 	}
 
 	// Receiver is the interface that wraps the basic methods for hb driver to receive hb messages

--- a/daemon/hb/hbdisk/hbrx.go
+++ b/daemon/hb/hbdisk/hbrx.go
@@ -83,26 +83,31 @@ func (t *rx) streamPeerDesc(node string) string {
 
 // Start implements the Start function of the Receiver interface for rx
 func (t *rx) Start(cmdC chan<- any, msgC chan<- *hbtype.Msg) error {
-	hbaudit.EnableAudit(t.ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
+	ctx, cancel := context.WithCancel(t.ctx)
+	t.ctx = ctx
+	t.cancel = cancel
+
+	hbaudit.EnableAudit(ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
 
 	t.log.Infof("starting with storage area: metadata_size + (max_slots x slot_size): %d + (%d x %d)", metaSize(t.base.maxSlots), t.base.maxSlots, sign.SlotSize)
 	nodeCount := len(t.nodes) + 1
 	if t.base.maxSlots < nodeCount {
+		cancel()
 		return fmt.Errorf("can't start: not enough slots for %d nodes", nodeCount)
 	}
 	if err := t.base.device.open(); err != nil {
 		err := fmt.Errorf("device %s: %w", t.base.path, err)
 		t.log.Warnf("startup failed: %s", err)
+		cancel()
 		return err
 	}
 	if err := t.base.scanMetadata(append(t.nodes, t.base.localhost)...); err != nil {
+		cancel()
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(t.ctx)
 	t.cmdC = cmdC
 	t.msgC = msgC
-	t.cancel = cancel
 
 	for _, node := range t.nodes {
 		cmdC <- hbctrl.CmdAddWatcher{

--- a/daemon/hb/hbdisk/hbtx.go
+++ b/daemon/hb/hbdisk/hbtx.go
@@ -63,15 +63,19 @@ func (t *tx) streamPeerDesc() string {
 
 // Start implements the Start function of Transmitter interface for tx
 func (t *tx) Start(cmdC chan<- interface{}, msgC <-chan []byte) error {
-	hbaudit.EnableAudit(t.ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
-
+	ctx, cancel := context.WithCancel(t.ctx)
+	t.ctx = ctx
+	t.cancel = cancel
+	hbaudit.EnableAudit(ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
 	t.log.Infof("starting with storage area: metadata_size + (max_slots x slot_size): %d + (%d x %d)", metaSize(t.base.maxSlots), t.base.maxSlots, sign.SlotSize)
 	if t.base.maxSlots < len(t.nodes) {
+		cancel()
 		return fmt.Errorf("startup failed: not enough slots for %d nodes", len(t.nodes))
 	}
 	if err := t.base.device.open(); err != nil {
 		err := fmt.Errorf("device %s: %w", t.base.path, err)
 		t.log.Warnf("startup failed: %s", err)
+		cancel()
 		return err
 	}
 
@@ -84,8 +88,6 @@ func (t *tx) Start(cmdC chan<- interface{}, msgC <-chan []byte) error {
 		t.slot = slot
 	}
 	reasonTick := fmt.Sprintf("send msg (interval %s)", t.interval)
-	ctx, cancel := context.WithCancel(t.ctx)
-	t.cancel = cancel
 	t.cmdC = cmdC
 	t.Add(1)
 	go func() {

--- a/daemon/hb/hbdisk/hbtx.go
+++ b/daemon/hb/hbdisk/hbtx.go
@@ -57,6 +57,10 @@ func (t *tx) Stop() error {
 	return nil
 }
 
+func (t *tx) Ctx() context.Context {
+	return t.ctx
+}
+
 func (t *tx) streamPeerDesc() string {
 	return fmt.Sprintf("→ %s slot %d", t.base.device.file.Name(), t.slot)
 }

--- a/daemon/hb/hbmcast/hbrx.go
+++ b/daemon/hb/hbmcast/hbrx.go
@@ -80,9 +80,10 @@ func (t *rx) Start(cmdC chan<- interface{}, msgC chan<- *hbtype.Msg) error {
 	ctx, cancel := context.WithCancel(t.ctx)
 	t.cmdC = cmdC
 	t.msgC = msgC
+	t.ctx = ctx
 	t.cancel = cancel
 
-	hbaudit.EnableAudit(t.ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
+	hbaudit.EnableAudit(ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
 
 	t.log.Infof("starting")
 	t.assembly = make(assembly)

--- a/daemon/hb/hbmcast/hbtx.go
+++ b/daemon/hb/hbmcast/hbtx.go
@@ -68,10 +68,11 @@ func (t *tx) streamPeerDesc() string {
 func (t *tx) Start(cmdC chan<- interface{}, msgC <-chan []byte) error {
 	started := make(chan bool)
 	ctx, cancel := context.WithCancel(t.ctx)
+	t.ctx = ctx
 	t.cancel = cancel
 	t.cmdC = cmdC
 
-	hbaudit.EnableAudit(t.ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
+	hbaudit.EnableAudit(ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
 
 	t.Add(1)
 	go func() {

--- a/daemon/hb/hbmcast/hbtx.go
+++ b/daemon/hb/hbmcast/hbtx.go
@@ -56,6 +56,10 @@ func (t *tx) Stop() error {
 	return nil
 }
 
+func (t *tx) Ctx() context.Context {
+	return t.ctx
+}
+
 func (t *tx) streamPeerDesc() string {
 	if t.laddr == nil {
 		return fmt.Sprintf("→ %s", t.udpAddr)

--- a/daemon/hb/hbrelay/hbtx.go
+++ b/daemon/hb/hbrelay/hbtx.go
@@ -52,6 +52,10 @@ func (t *tx) Stop() error {
 	return nil
 }
 
+func (t *tx) Ctx() context.Context {
+	return t.ctx
+}
+
 func (t *tx) streamPeerDesc() string {
 	return fmt.Sprintf("→ %s@%s", t.username, t.relay)
 }

--- a/daemon/hb/hbucast/hbrx.go
+++ b/daemon/hb/hbucast/hbrx.go
@@ -101,8 +101,9 @@ func (t *rx) Start(cmdC chan<- interface{}, msgC chan<- *hbtype.Msg) error {
 	t.cmdC = cmdC
 	t.msgC = msgC
 	t.cancel = cancel
+	t.ctx = ctx
 
-	hbaudit.EnableAudit(t.ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
+	hbaudit.EnableAudit(ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
 
 	t.log.Infof("starting: timeout %s", t.timeout)
 
@@ -128,6 +129,7 @@ func (t *rx) Start(cmdC chan<- interface{}, msgC chan<- *hbtype.Msg) error {
 				time.Sleep(delay)
 				continue
 			}
+			cancel()
 			return err
 		}
 		break

--- a/daemon/hb/hbucast/hbtx.go
+++ b/daemon/hb/hbucast/hbtx.go
@@ -58,6 +58,10 @@ func (t *tx) Stop() error {
 	return nil
 }
 
+func (t *tx) Ctx() context.Context {
+	return t.ctx
+}
+
 func (t *tx) streamPeerDesc(addr string) string {
 	if len(t.localIP) > 0 {
 		if t.intf != "" {

--- a/daemon/hb/hbucast/hbtx.go
+++ b/daemon/hb/hbucast/hbtx.go
@@ -78,10 +78,11 @@ func (t *tx) streamPeerDesc(addr string) string {
 func (t *tx) Start(cmdC chan<- interface{}, msgC <-chan []byte) error {
 	started := make(chan bool)
 	ctx, cancel := context.WithCancel(t.ctx)
+	t.ctx = ctx
 	t.cancel = cancel
 	t.cmdC = cmdC
 	t.Add(1)
-	hbaudit.EnableAudit(t.ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
+	hbaudit.EnableAudit(ctx, t.id, t.log, "hb", strings.Replace(t.id, "hb#", "hb:", 1))
 
 	go func() {
 		defer t.Done()

--- a/daemon/hb/main.go
+++ b/daemon/hb/main.go
@@ -188,12 +188,16 @@ func (t *T) startHbTx(hb hbcfg.Confer) error {
 	// It can't be stalled because of slow hb transmitter.
 	debouncedMsgQ := make(chan []byte)
 	msgToSendQ := make(chan []byte)
-	go debounceLatestMsgToTx(t.msgToTxCtx, msgToSendQ, debouncedMsgQ)
 
 	if err := tx.Start(t.ctrlC, debouncedMsgQ); err != nil {
 		t.ctrlC <- hbctrl.CmdSetState{ID: tx.ID(), State: "failed"}
 		return err
 	}
+	go func(ctx context.Context) {
+		debounceLatestMsgToTx(ctx, t.msgToTxCtx, msgToSendQ, debouncedMsgQ)
+		t.log.Infof("debounceLatestMsgToTx done for %s", tx.ID())
+	}(tx.Ctx())
+
 	select {
 	case <-t.msgToTxCtx.Done():
 		// don't hang up when context is done
@@ -626,7 +630,8 @@ func (t *T) getHbConfiguredComponent(ctx context.Context, rid string) (c hbcfg.C
 // debounceLatestMsgToTx is used to relay dequeued messages from inQ
 // to outC, without blocking on outQ (the last dequeued message from
 // inQ will replace the relay bloqued message to outQ).
-func debounceLatestMsgToTx(ctx context.Context, inQ <-chan []byte, outC chan<- []byte) {
+// the function returns when tx context, or msgToTxCtx is Done
+func debounceLatestMsgToTx(txCtx, msgToTxCtx context.Context, inQ <-chan []byte, outC chan<- []byte) {
 	var (
 		b []byte
 		o chan<- []byte
@@ -637,7 +642,9 @@ func debounceLatestMsgToTx(ctx context.Context, inQ <-chan []byte, outC chan<- [
 			o = outC
 		case o <- b:
 			o = nil
-		case <-ctx.Done():
+		case <-txCtx.Done():
+			return
+		case <-msgToTxCtx.Done():
 			return
 		}
 	}


### PR DESCRIPTION
### Summary

This pull request addresses two key issues in the heartbeat system:

1. **Goroutine leak in debounceLatestMsgToTx:** Updated the handling of transmitter contexts (`txCtx`) in `debounceLatestMsgToTx` to improve consistency and ensure cleanup after `stop tx`.
2. **Goroutine leak in hbaudit.EnableAudit:** Fixed context management for `hbaudit.EnableAudit` to ensure proper initialization and prevent resource leaks after `stop tx` or `rx`.

### Changes
- Added a `Ctx()` method for heartbeat transmitter implementations to facilitate consistent context retrieval.
- Refined context management to improve reliability across heartbeat drivers.
- Appropriately used `cancel()` calls to prevent resource leaks in both `debounceLatestMsgToTx` and `hbaudit.EnableAudit`.
- Improved audit initialization logic to always use the current, updated context.
