### PR TITLE
Introduce SGCP NFS driver and supporting infrastructure

### DIFF
--- a/core/driverdb/drivers.go
+++ b/core/driverdb/drivers.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/opensvc/om3/v3/drivers/resfsdir"
 	_ "github.com/opensvc/om3/v3/drivers/resfsflag"
 	_ "github.com/opensvc/om3/v3/drivers/resfshost"
+	_ "github.com/opensvc/om3/v3/drivers/resfssgcp_nfs"
 	_ "github.com/opensvc/om3/v3/drivers/resfszfs"
 	_ "github.com/opensvc/om3/v3/drivers/resiphost"
 	_ "github.com/opensvc/om3/v3/drivers/resiproute"

--- a/core/object/datastore.go
+++ b/core/object/datastore.go
@@ -30,6 +30,7 @@ type (
 		AddKey(name string, b []byte) error
 		ChangeKey(name string, b []byte) error
 		DecodeKey(name string) ([]byte, error)
+		DecodeKeys(name ...string) ([][]byte, error)
 		EditKey(name string) error
 		InstallKey(name string) error
 		InstallKeyTo(KVInstall) error

--- a/core/object/datastore_key_decode.go
+++ b/core/object/datastore_key_decode.go
@@ -27,3 +27,16 @@ func (t *dataStore) decode(keyname string) ([]byte, error) {
 func (t *dataStore) DecodeKey(keyname string) ([]byte, error) {
 	return t.decode(keyname)
 }
+
+// DecodeKeys returns the decoded bytes of the key value
+func (t *dataStore) DecodeKeys(keynames ...string) ([][]byte, error) {
+	var l [][]byte
+	for _, keyname := range keynames {
+		if b, err := t.decode(keyname); err != nil {
+			return nil, fmt.Errorf("decode key %s: %w", keyname, err)
+		} else {
+			l = append(l, b)
+		}
+	}
+	return l, nil
+}

--- a/drivers/resfshost/manifest.go
+++ b/drivers/resfshost/manifest.go
@@ -66,11 +66,21 @@ var (
 		Scopable: true,
 		Text:     keywords.NewText(fs, "text/kw/zone"),
 	}
-	KeywordCheckRead = keywords.Keyword{
+	KeywordCheckReadDisabled = keywords.Keyword{
+		Attr:      "CheckRead",
+		Converter: "bool",
+		Option:    "check_read",
+		Default:   "false",
+		Scopable:  true,
+		Text:      keywords.NewText(fs, "text/kw/check_read"),
+	}
+
+	KeywordCheckReadEnabled = keywords.Keyword{
 		Attr:      "CheckRead",
 		Converter: "bool",
 		Option:    "check_read",
 		Scopable:  true,
+		Default:   "true",
 		Text:      keywords.NewText(fs, "text/kw/check_read"),
 	}
 
@@ -82,7 +92,7 @@ var (
 		&KeywordPromoteRW,
 		&KeywordMKFSOptions,
 		&KeywordZone,
-		&KeywordCheckRead,
+		&KeywordCheckReadDisabled,
 	}
 )
 

--- a/drivers/resfshost/manifest.go
+++ b/drivers/resfshost/manifest.go
@@ -74,34 +74,12 @@ var (
 		Text:      keywords.NewText(fs, "text/kw/check_read"),
 	}
 
-	KeywordsVirtual = []*keywords.Keyword{
-		&KeywordMountPoint,
-		&KeywordMountOptions,
-		&KeywordDevice,
-		&KeywordStatTimeout,
-		&KeywordZone,
-		&KeywordCheckRead,
-	}
-
 	KeywordsBase = []*keywords.Keyword{
 		&KeywordMountPoint,
 		&KeywordDevice,
 		&KeywordMountOptions,
 		&KeywordStatTimeout,
-		&manifest.KWSCSIPersistentReservationKey,
-		&manifest.KWSCSIPersistentReservationEnabled,
-		&manifest.KWSCSIPersistentReservationNoPreemptAbort,
 		&KeywordPromoteRW,
-		&KeywordMKFSOptions,
-		&KeywordZone,
-		&KeywordCheckRead,
-	}
-
-	KeywordsPooling = []*keywords.Keyword{
-		&KeywordMountPoint,
-		&KeywordDevice,
-		&KeywordMountOptions,
-		&KeywordStatTimeout,
 		&KeywordMKFSOptions,
 		&KeywordZone,
 		&KeywordCheckRead,

--- a/drivers/resfssgcp_nfs/api.go
+++ b/drivers/resfssgcp_nfs/api.go
@@ -1,0 +1,261 @@
+package resfssgcp_nfs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/opensvc/om3/v3/util/ageingcache"
+	"github.com/opensvc/om3/v3/util/plog"
+	"github.com/opensvc/om3/v3/util/sgcp"
+)
+
+type (
+	// nfsClientMgr handles NFS client management for the resource
+	nfsClientMgr struct {
+		uuid       string
+		host       string
+		permission string
+		protocol   string
+		nfsIgnored []string
+
+		api         *sgcp.FilesAPI
+		cacheConfig *sgcp.CacheConfig
+		log         *plog.Logger
+	}
+)
+
+// Start adds the NFS client to the filesystem
+func (mgr *nfsClientMgr) Start(ctx context.Context, exclusive bool) error {
+	if exclusive {
+		return mgr.startExclusive(ctx)
+	}
+	return mgr.start(ctx)
+}
+
+func (mgr *nfsClientMgr) start(ctx context.Context) error {
+	// Verify if the client already exists
+	fileInfo, err := mgr.getFileInfo(ctx)
+	if err != nil {
+		return err
+	}
+
+	if fileInfo != nil {
+		for _, client := range fileInfo.NFSClients {
+			if client.Host == mgr.host {
+				if client.Permission == mgr.permission {
+					mgr.log.Infof("%s already exists", client)
+					return nil
+				}
+				// Wrong permission, delete and recreate
+				if err := mgr.deleteNFSClient(ctx, client); err != nil {
+					// Don't stop here, next addNFSClient will retry delete wrong permission
+					mgr.log.Debugf("continue (will be retried) on failed deletion of NFS client with wrong permission: %s", err)
+				}
+				break
+			}
+		}
+	}
+
+	// Add the client
+	_, err = mgr.addNFSClient(ctx, mgr.host)
+	return err
+}
+
+// startExclusive starts with exclusive access (removes other clients first)
+func (mgr *nfsClientMgr) startExclusive(ctx context.Context) error {
+	// Delete all clients except our host
+	fileInfo, err := mgr.getFileInfo(ctx)
+	if err != nil {
+		return err
+	}
+
+	if fileInfo != nil {
+		for _, client := range fileInfo.NFSClients {
+			if client.Host != mgr.host && !mgr.isClientIgnored(client.Host) {
+				if err := mgr.deleteNFSClient(ctx, client); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Add our client
+	_, err = mgr.addNFSClient(ctx, mgr.host)
+	return err
+}
+
+func (mgr *nfsClientMgr) cacheSig(name string) string {
+	return fmt.Sprintf("%s:%s", name, mgr.uuid)
+}
+
+func (mgr *nfsClientMgr) cacheClear(name string) error {
+	cacheSig := mgr.cacheSig(name)
+	return ageingcache.Clear(cacheSig)
+}
+
+func (mgr *nfsClientMgr) getFileInfo(ctx context.Context) (*FilesystemInfo, error) {
+	var fileInfo FilesystemInfo
+
+	cacheSig := mgr.cacheSig("getFileInfo")
+	ttl := time.Duration(mgr.cacheConfig.TTLSeconds) * time.Second
+	o := ageingcache.NewOutputter(mgr.getFileInfoFactory(ctx))
+	data, err := ageingcache.Output(o, cacheSig, ttl)
+	if err != nil {
+		mgr.log.Debugf("getFileInfo failed on missing cache sig %s.out, ttl: %s: %s", cacheSig, ttl, err)
+		return nil, fmt.Errorf("getFileInfo failed: %w", err)
+	}
+
+	if err := json.Unmarshal(data, &fileInfo); err != nil {
+		return nil, err
+	}
+
+	return &fileInfo, err
+}
+
+func (mgr *nfsClientMgr) getFileInfoFactory(ctx context.Context) func() ([]byte, error) {
+	return func() ([]byte, error) {
+		method, url, statusCode, data, err := mgr.api.GetFilesystem(ctx, mgr.uuid)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := mgr.api.CheckStatusCode(method, url, statusCode, http.StatusNotFound, http.StatusOK); err != nil {
+			return nil, err
+		}
+		switch statusCode {
+		case http.StatusOK:
+		case http.StatusNotFound:
+			return nil, nil
+		default:
+			// paranoid, should never happen
+			return nil, fmt.Errorf("%s %s got unexpected status code %d", method, url, statusCode)
+		}
+		return data, nil
+	}
+}
+
+// Stop removes the NFS client for this host
+func (mgr *nfsClientMgr) Stop(ctx context.Context) error {
+	fileInfo, err := mgr.getFileInfo(ctx)
+	if err != nil {
+		return err
+	}
+
+	if fileInfo == nil {
+		return nil
+	}
+
+	for _, client := range fileInfo.NFSClients {
+		if client.Host == mgr.host {
+			return mgr.deleteNFSClient(ctx, client)
+		}
+	}
+
+	return nil
+}
+
+// addNFSClient adds a new NFS client to the filesystem
+func (mgr *nfsClientMgr) addNFSClient(ctx context.Context, host string) (*NfsClient, error) {
+	newClient := &NfsClient{
+		Host:       host,
+		Permission: mgr.permission,
+		Protocol:   mgr.protocol,
+	}
+
+	mgr.log.Debugf("Verify existence of %s", newClient)
+
+	fileInfo, err := mgr.getFileInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if fileInfo != nil {
+		for _, client := range fileInfo.NFSClients {
+			if client.Host == host {
+				if client.Permission == mgr.permission {
+					mgr.log.Infof("%s already exists", client)
+					return &client, nil
+				}
+				mgr.log.Infof("%s already exists, with wrong permission", client)
+				if err := mgr.deleteNFSClient(ctx, client); err != nil {
+					mgr.log.Warnf("delete existing %s with wrong permissions: %s", client, err)
+				}
+				break
+			}
+		}
+	}
+	payload := &sgcp.NfsClient{
+		Host:       host,
+		Permission: mgr.permission,
+		Protocol:   mgr.protocol,
+	}
+	mgr.log.Infof("grant permission %s for host %s on filesystem %s ...", mgr.permission, host, mgr.uuid)
+	method, url, statusCode, data, err := mgr.api.PostNFSClients(ctx, mgr.uuid, payload)
+
+	if err != nil {
+		return nil, err
+	}
+	if err := mgr.api.CheckStatusCode(method, url, statusCode, http.StatusCreated); err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected status code %s %s: %d", method, url, statusCode)
+	}
+	var createdClient NfsClient
+	if err := json.Unmarshal(data, &createdClient); err != nil {
+		return nil, err
+	}
+
+	mgr.log.Infof("created %s on filesystem %s", createdClient, mgr.uuid)
+	return &createdClient, nil
+}
+
+// deleteNFSClient deletes an NFS client from the filesystem
+func (mgr *nfsClientMgr) deleteNFSClient(ctx context.Context, client NfsClient) error {
+	cgMsg := ""
+	if client.ConsistencyGroupID != "" {
+		cgMsg = fmt.Sprintf(" in consistency group %s", client.ConsistencyGroupID)
+	}
+
+	mgr.log.Infof("drop permission %s for host %s on filesystem %s%s ...", client.Permission, client.Host, mgr.uuid, cgMsg)
+	method, url, statusCode, _, err := mgr.api.DeleteNFSClients(ctx, mgr.uuid, client.UUID)
+	if err != nil {
+		return err
+	}
+	if err := mgr.api.CheckStatusCode(method, url, statusCode, http.StatusNoContent, http.StatusPreconditionFailed); err != nil {
+		return err
+	}
+	switch statusCode {
+	case http.StatusNoContent:
+	case http.StatusPreconditionFailed:
+		return fmt.Errorf("consistency group is not in ready (status_code %d)", statusCode)
+	default:
+		// paranoid, should never happen
+		return fmt.Errorf("unexpected status code %d", statusCode)
+	}
+
+	mgr.log.Infof("deleted %s on filesystem %s", client, mgr.uuid)
+	return nil
+}
+
+func (mgr *nfsClientMgr) checkStatusCode(method, url string, got int, wanted ...int) error {
+	mgr.log.Debugf("%s %s status code: %d", method, url, got)
+	if slices.Contains(wanted, got) {
+		return nil
+	}
+	return fmt.Errorf("unexpected status code for %s %s got %d wanted %v", method, url, got, wanted)
+}
+
+// isClientIgnored checks if a client host should be ignored
+func (mgr *nfsClientMgr) isClientIgnored(host string) bool {
+	for _, ignored := range mgr.nfsIgnored {
+		if host == ignored {
+			return true
+		}
+	}
+	return false
+}

--- a/drivers/resfssgcp_nfs/caps.go
+++ b/drivers/resfssgcp_nfs/caps.go
@@ -1,0 +1,15 @@
+package resfssgcp_nfs
+
+import (
+	"context"
+
+	"github.com/opensvc/om3/v3/util/capabilities"
+)
+
+func init() {
+	capabilities.Register(capabilitiesScanner)
+}
+
+func capabilitiesScanner(ctx context.Context) ([]string, error) {
+	return []string{drvID.Cap()}, nil
+}

--- a/drivers/resfssgcp_nfs/main.go
+++ b/drivers/resfssgcp_nfs/main.go
@@ -1,0 +1,404 @@
+// Package resfssgcp_nfs provides the SGCP NFS filesystem driver
+package resfssgcp_nfs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/opensvc/om3/v3/core/datarecv"
+	"github.com/opensvc/om3/v3/core/rawconfig"
+	"github.com/opensvc/om3/v3/core/resource"
+	"github.com/opensvc/om3/v3/core/status"
+	"github.com/opensvc/om3/v3/drivers/resfshost"
+	"github.com/opensvc/om3/v3/drivers/sgcphelper"
+	"github.com/opensvc/om3/v3/util/httpclientcache"
+	"github.com/opensvc/om3/v3/util/sgcp"
+)
+
+type (
+	// NfsClient represents an NFS client configuration
+	NfsClient struct {
+		UUID               string `json:"uuid"`
+		Host               string `json:"host"`
+		Permission         string `json:"permission"`
+		Protocol           string `json:"protocol"`
+		ConsistencyGroupID string `json:"consistencyGroupId,omitempty"`
+	}
+
+	// FilesystemInfo represents the filesystem information from the API
+	FilesystemInfo struct {
+		UUID               string      `json:"uuid"`
+		ConsistencyGroupID string      `json:"consistencyGroupId"`
+		NFSClients         []NfsClient `json:"nfsClients"`
+		Status             string      `json:"status"`
+	}
+
+	// T represents the SGCP NFS filesystem resource
+	T struct {
+		resource.T
+		resource.Restart
+		datarecv.DataRecv
+
+		// Configuration parameters
+		UUID       string `json:"uuid"`
+		Host       string `json:"host,omitempty"`
+		Permission string `json:"permission,omitempty"`
+		Exclusive  bool   `json:"exclusive,omitempty"`
+		Protocol   string `json:"protocol,omitempty"`
+		Secret     string `json:"secret,omitempty"`
+		Endpoint   string `json:"endpoint,omitempty"`
+		Path       string `json:"path,omitempty"`
+
+		// Configuration parameters for the underlying filesystem resource
+		MountPoint   string         `json:"mnt"`
+		Device       string         `json:"dev"`
+		Type         string         `json:"type"`
+		MountOptions string         `json:"mnt_opt"`
+		StatTimeout  *time.Duration `json:"stat_timeout"`
+		Zone         string         `json:"zone"`
+		CheckRead    bool           `json:"check_read"`
+
+		// Internal state
+		resFs         fsDriver
+		fileInfoCache *FilesystemInfo
+		mgr           *nfsClientMgr
+		authInfoer    GetAuthInfoer
+	}
+
+	GetAuthInfoer interface {
+		GetAuthInfo(string) (*sgcp.AuthInfo, error)
+	}
+
+	fsDriver interface {
+		Start(context.Context) error
+		Stop(context.Context) error
+		Status(context.Context) status.T
+		StatusLog() resource.StatusLogger
+		Label(context.Context) string
+		Head() string
+		CanInstall(context.Context) (bool, error)
+	}
+)
+
+// NfsClientIgnored is a list of NFS client hosts to ignore
+var NfsClientIgnored = []string{}
+
+// New creates a new SGCP NFS filesystem resource driver
+func New() resource.Driver {
+	return &T{}
+}
+
+// Configure sets up the resource
+func (t *T) Configure() error {
+	cfg := sgcp.GetConfig()
+
+	// set defaults when kw are not set
+	if t.Secret == "" {
+		t.Secret = cfg.Auth.DefaultSecret
+	}
+	if t.Endpoint == "" {
+		t.Endpoint = cfg.Files.BaseURL
+	}
+	if t.Permission == "" {
+		t.Permission = DefaultPermission
+	}
+	if t.Protocol == "" {
+		t.Protocol = DefaultProtocol
+	}
+
+	if t.Endpoint != "" {
+		cfg = cfg.WithFileURL(t.Endpoint)
+	}
+	if t.Secret != "" {
+		cfg = cfg.WithAuthSecret(t.Secret)
+	}
+
+	if err := t.configureMgr(cfg); err != nil {
+		return fmt.Errorf("configure mgr: %w", err)
+	}
+
+	if err := t.configureUnderlyingFilesystem("nfs"); err != nil {
+		return fmt.Errorf("configure underlying filesystem: %w", err)
+	}
+
+	return nil
+}
+
+func (t *T) configureMgr(cfg *sgcp.Config) error {
+	// Initialize SGCP API client
+	httpClient, err := httpclientcache.Client(httpclientcache.Options{
+		Timeout: 30 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+
+	if t.authInfoer == nil {
+		t.authInfoer = &sgcphelper.GetAuthInfoFromDatastorePather{}
+	}
+
+	authInfo, err := t.authInfoer.GetAuthInfo(t.Secret)
+	if err != nil {
+		return fmt.Errorf("get auth info: %w", err)
+	}
+	tk := sgcp.NewTokenFactory(t.Log(), httpClient, &cfg.Auth, authInfo)
+
+	t.mgr = &nfsClientMgr{
+		uuid:        t.UUID,
+		host:        t.Host,
+		permission:  t.Permission,
+		protocol:    t.Protocol,
+		log:         t.Log(),
+		nfsIgnored:  NfsClientIgnored,
+		api:         sgcp.NewFilesAPI(cfg, httpClient, t.Log(), tk),
+		cacheConfig: &cfg.Cache,
+	}
+	return nil
+}
+
+func (t *T) configureUnderlyingFilesystem(resType string) error {
+	// Prepare the underlying filesystem resource
+	r := resfshost.New().(*resfshost.T)
+	if err := r.SetRID(t.RID()); err != nil {
+		return fmt.Errorf("set underlying fs rid: %w", err)
+	}
+	if o := t.GetObject(); o != nil {
+		r.SetObject(t.GetObject())
+	}
+	r.Type = resType
+	r.Device = t.Device
+	r.MountPoint = t.MountPoint
+	r.MountOptions = t.MountOptions
+	r.StatTimeout = t.StatTimeout
+	r.DataRecv = t.DataRecv
+	r.Perm = t.Perm
+	if err := r.Configure(); err != nil {
+		return fmt.Errorf("configure underlying fs: %w", err)
+	}
+	t.resFs = r
+
+	t.DataRecv.SetReceiver(r)
+	return nil
+}
+
+// Start starts the SGCP NFS filesystem resource
+func (t *T) Start(ctx context.Context) error {
+	// Start the XaaS (SGCP API) part
+	if err := t.fileStart(ctx); err != nil {
+		return err
+	}
+
+	// Start underlying fs, this includes the data receive step
+	if err := t.resFs.Start(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Stop stops the SGCP NFS filesystem resource
+func (t *T) Stop(ctx context.Context) error {
+	// stop the underlying filesystem
+	if err := t.resFs.Stop(ctx); err != nil {
+		return err
+	}
+
+	// Stop the XaaS part
+	return t.fileStop(ctx)
+}
+
+// Status returns the combined status of the file and fs
+func (t *T) Status(ctx context.Context) status.T {
+	fileStatus := t.fileStatus(ctx)
+
+	// Get underlying filesystem status
+	fsStatus := t.resFs.Status(ctx)
+	t.StatusLog().Merge(t.resFs.StatusLog())
+
+	fileStatus.Add(fsStatus)
+	return fileStatus
+}
+
+// Head returns the head path for the data receiver
+func (t *T) Head() string {
+	return t.resFs.Head()
+}
+
+// Label returns a label for the resource
+func (t *T) Label(ctx context.Context) string {
+	return t.resFs.Label(ctx)
+}
+
+// CanInstall checks if the resource can be installed
+func (t *T) CanInstall(ctx context.Context) (bool, error) {
+	return t.resFs.CanInstall(ctx)
+}
+
+// Boot stops the resource (for daemon bootstrap)
+func (t *T) Boot(ctx context.Context) error {
+	return t.Stop(ctx)
+}
+
+// fileStart handles the SGCP API part of starting the filesystem
+func (t *T) fileStart(ctx context.Context) error {
+	if sgcp.IsDisabled(rawconfig.NodeVarDir()) {
+		t.Log().Infof("skipping file start %s: SGCP API disabled", t.UUID)
+		return nil
+	}
+
+	t.Log().Infof("starting file %s", t.UUID)
+
+	// Clear cache to get fresh data
+	if err := t.clearFileStatusCache(); err != nil {
+		return fmt.Errorf("clear cache: %w", err)
+	}
+
+	// Check current status
+	if t.fileStatus(ctx) == status.Up {
+		t.Log().Infof("permission %s from host %s already created", t.Permission, t.Host)
+		return nil
+	}
+
+	// Start the NFS client
+	return t.mgr.Start(ctx, t.Exclusive)
+}
+
+// fileStop handles the SGCP API part of stopping the filesystem
+func (t *T) fileStop(ctx context.Context) error {
+	if sgcp.IsDisabled(rawconfig.NodeVarDir()) {
+		t.Log().Infof("skipping file stop %s: SGCP API disabled", t.UUID)
+		return nil
+	}
+	t.Log().Infof("stopping file %s", t.UUID)
+
+	// Clear cache to get fresh data
+	if err := t.clearFileStatusCache(); err != nil {
+		return fmt.Errorf("clear cache: %w", err)
+	}
+
+	// Check current status
+	if t.fileStatus(ctx) == status.Down {
+		t.Log().Infof("permission %s from host %s already deleted", t.Permission, t.Host)
+		return nil
+	}
+
+	return t.mgr.Stop(ctx)
+}
+
+// fileStatus returns the status of the filesystem from the SGCP API
+func (t *T) fileStatus(ctx context.Context) status.T {
+	// Check if XaaS status is disabled
+	if sgcp.IsDisabled(rawconfig.NodeVarDir()) {
+		t.Log().Debugf("skipping file status %s: SGCP API disabled", t.UUID)
+		return status.NotApplicable
+	}
+
+	fileInfo, err := t.getFileInfo(ctx)
+	if err != nil {
+		t.Log().Debugf("file object not visible in api: %s", err)
+		t.StatusLog().Info("file object not visible in api")
+		return status.Down
+	}
+
+	if fileInfo == nil {
+		t.StatusLog().Info("file object not visible in api")
+		return status.Down
+	}
+
+	clients := t.getNFSClients(fileInfo)
+	n := len(clients)
+
+	if t.Exclusive {
+		if n > 1 {
+			t.StatusLog().Warn(fmt.Sprintf("too many grants (%d)", n))
+		}
+	}
+
+	if n == 0 {
+		t.StatusLog().Info("no access granted")
+		return status.Down
+	}
+
+	// Filter clients to only those matching our host and permission
+	var matchingClients []NfsClient
+	for _, client := range clients {
+		if client.Host == t.Host && client.Permission == t.Permission {
+			matchingClients = append(matchingClients, client)
+		}
+	}
+
+	if len(matchingClients) == 0 {
+		t.StatusLog().Info("access not in current grants")
+		return status.Down
+	}
+
+	if fileInfo.Status == "passive" {
+		t.StatusLog().Info("status passive, access granted")
+		return status.Down
+	}
+
+	return status.Up
+}
+
+// getFileInfo retrieves filesystem information from the API
+func (t *T) getFileInfo(ctx context.Context) (*FilesystemInfo, error) {
+	// Use cached value if available
+	if t.fileInfoCache != nil {
+		return t.fileInfoCache, nil
+	}
+
+	fileInfo, err := t.mgr.getFileInfo(ctx)
+	if err == nil {
+		// Cache the result
+		t.fileInfoCache = fileInfo
+	}
+
+	return fileInfo, err
+}
+
+// getNFSClients returns the NFS clients for the filesystem, filtered by ignored hosts
+func (t *T) getNFSClients(fileInfo *FilesystemInfo) []NfsClient {
+	if fileInfo == nil {
+		return []NfsClient{}
+	}
+
+	var filteredClients []NfsClient
+	for _, client := range fileInfo.NFSClients {
+		if !t.isClientIgnored(client.Host) {
+			filteredClients = append(filteredClients, client)
+		}
+	}
+
+	return filteredClients
+}
+
+// isClientIgnored checks if a client host should be ignored
+func (t *T) isClientIgnored(host string) bool {
+	for _, ignored := range NfsClientIgnored {
+		if host == ignored {
+			return true
+		}
+	}
+	return false
+}
+
+// clearFileStatusCache clears the filesystem info cache
+func (t *T) clearFileStatusCache() error {
+	var errs error
+	t.fileInfoCache = nil
+	for _, s := range []string{"getFileInfo"} {
+		errs = errors.Join(errs, t.mgr.cacheClear(s))
+	}
+	return errs
+}
+
+// String returns a string representation of an NfsClient
+func (c *NfsClient) String() string {
+	if c == nil {
+		return "NfsClient <nil>"
+	}
+	return fmt.Sprintf("NfsClient uuid:%s, host:%s, protocol:%s, permission:%s",
+		c.UUID, c.Host, c.Protocol, c.Permission)
+}

--- a/drivers/resfssgcp_nfs/main.go
+++ b/drivers/resfssgcp_nfs/main.go
@@ -98,21 +98,26 @@ func (t *T) Configure() error {
 	if t.Secret == "" {
 		t.Secret = cfg.Auth.DefaultSecret
 	}
+	if t.Secret == "" {
+		return fmt.Errorf("secret is required (neither defined into secret keyword nor config file %s", sgcp.DefaultConfigPath)
+	} else {
+		cfg = cfg.WithAuthSecret(t.Secret)
+	}
+
 	if t.Endpoint == "" {
 		t.Endpoint = cfg.Files.BaseURL
 	}
+	if t.Endpoint == "" {
+		return fmt.Errorf("file endpoint is required (neither defined into endpoint keyword nor config file %s", sgcp.DefaultConfigPath)
+	} else {
+		cfg = cfg.WithFileURL(t.Endpoint)
+	}
+
 	if t.Permission == "" {
 		t.Permission = DefaultPermission
 	}
 	if t.Protocol == "" {
 		t.Protocol = DefaultProtocol
-	}
-
-	if t.Endpoint != "" {
-		cfg = cfg.WithFileURL(t.Endpoint)
-	}
-	if t.Secret != "" {
-		cfg = cfg.WithAuthSecret(t.Secret)
 	}
 
 	if err := t.configureMgr(cfg); err != nil {

--- a/drivers/resfssgcp_nfs/main_test.go
+++ b/drivers/resfssgcp_nfs/main_test.go
@@ -1,0 +1,338 @@
+package resfssgcp_nfs
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opensvc/om3/v3/core/driver"
+	"github.com/opensvc/om3/v3/core/resource"
+	"github.com/opensvc/om3/v3/core/status"
+	"github.com/opensvc/om3/v3/util/sgcp"
+)
+
+func newDrvWithRid(s string) *T {
+	d := New().(*T)
+	if err := d.SetRID(s); err != nil {
+		panic(err)
+	}
+	return d
+}
+
+type (
+	tAuthInfo struct {
+		sgcp.AuthInfo
+	}
+)
+
+func (a *tAuthInfo) GetAuthInfo(string) (*sgcp.AuthInfo, error) {
+	return &a.AuthInfo, nil
+}
+
+func tCreateAuthInfo(s string) *tAuthInfo {
+	var a sgcp.AuthInfo
+	switch s {
+	case "id1":
+		a = sgcp.AuthInfo{
+			AccountID:    "account_1",
+			ClientID:     "client_id_1",
+			ClientSecret: "client_secret_1",
+			Signature:    "1",
+		}
+	default:
+		a = sgcp.AuthInfo{
+			AccountID:    "account_default",
+			ClientID:     "client_id_efault",
+			ClientSecret: "client_secret_default",
+			Signature:    "default",
+		}
+	}
+	return &tAuthInfo{AuthInfo: a}
+}
+
+// TestDriverID tests that the driver has the correct ID
+func TestDriverID(t *testing.T) {
+	drv := New()
+	assert.Equal(t, driver.NewID(driver.GroupFS, "sgcp_nfs"), drv.DriverID())
+}
+
+// TestNew creates a new driver instance
+func TestNew(t *testing.T) {
+	drv := New()
+	require.NotNil(t, drv)
+
+	// Check that it implements the resource.Driver interface
+	_, ok := drv.(resource.Driver)
+	assert.True(t, ok)
+}
+
+// TestConfigure tests driver configuration
+func TestConfigure(t *testing.T) {
+	drv := newDrvWithRid("test-rid")
+	drv.authInfoer = tCreateAuthInfo("id1")
+	// Set configuration
+	drv.UUID = "test-uuid"
+	drv.Host = "test-host"
+	drv.Permission = "read-write"
+	drv.Protocol = "nfs4.1"
+	// Configure should not fail with valid config
+	err := drv.Configure()
+	assert.NoError(t, err)
+
+	// Check defaults
+	assert.Equal(t, "read-write", drv.Permission)
+	assert.Equal(t, "nfs4.1", drv.Protocol)
+	assert.Equal(t, "iam", drv.Secret)
+	assert.Equal(t, sgcp.DefaultBaseURL, drv.Endpoint)
+}
+
+// TestConfigureWithMissingUUID tests configuration validation
+func TestConfigureWithMissingUUID(t *testing.T) {
+	drv := newDrvWithRid("test-rid")
+	drv.authInfoer = tCreateAuthInfo("id1")
+
+	// This should still work since UUID is set via the configuration
+	drv.UUID = "test-uuid"
+	err := drv.Configure()
+	assert.NoError(t, err)
+}
+
+// TestIsClientIgnored tests the client ignored functionality
+func TestIsClientIgnored(t *testing.T) {
+	drv := newDrvWithRid("test-rid")
+	drv.authInfoer = tCreateAuthInfo("id1")
+
+	err := drv.Configure()
+	assert.NoError(t, err)
+
+	// Add some ignored hosts
+	NfsClientIgnored = []string{"ignored1", "ignored2"}
+
+	assert.True(t, drv.isClientIgnored("ignored1"))
+	assert.True(t, drv.isClientIgnored("ignored2"))
+	assert.False(t, drv.isClientIgnored("valid-host"))
+}
+
+// TestClientString tests the client string representation
+func TestClientString(t *testing.T) {
+	client := &NfsClient{
+		UUID:       "client-uuid",
+		Host:       "client-host",
+		Permission: "read-write",
+		Protocol:   "nfs4.1",
+	}
+
+	str := client.String()
+	assert.Contains(t, str, "client-uuid")
+	assert.Contains(t, str, "client-host")
+	assert.Contains(t, str, "read-write")
+	assert.Contains(t, str, "nfs4.1")
+}
+
+// TestGetNFSClients tests filtering of NFS clients
+func TestGetNFSClients(t *testing.T) {
+	drv := newDrvWithRid("test-rid")
+	drv.authInfoer = tCreateAuthInfo("id1")
+	require.NoError(t, drv.Configure())
+
+	// Set up ignored hosts
+	NfsClientIgnored = []string{"ignored-host"}
+
+	fileInfo := &FilesystemInfo{
+		UUID: "fs-uuid",
+		NFSClients: []NfsClient{
+			{UUID: "client1", Host: "host1", Permission: "read-write", Protocol: "nfs4.1"},
+			{UUID: "client2", Host: "ignored-host", Permission: "read-write", Protocol: "nfs4.1"},
+			{UUID: "client3", Host: "host2", Permission: "read-only", Protocol: "nfs4.1"},
+		},
+	}
+
+	clients := drv.getNFSClients(fileInfo)
+
+	// Should have 2 clients (ignored-host should be filtered out)
+	assert.Len(t, clients, 2)
+
+	// Check that the ignored host is not in the result
+	hosts := []string{}
+	for _, client := range clients {
+		hosts = append(hosts, client.Host)
+	}
+	assert.NotContains(t, hosts, "ignored-host")
+}
+
+// TestFileStatusWithNoClients tests status when no clients are available
+func TestFileStatusWithNoClients(t *testing.T) {
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"uuid": "test-uuid", "nfsClients": [], "status": "online"}`))
+	}))
+	defer server.Close()
+
+	// Create a mock HTTP client that uses our test server
+	client := server.Client()
+	_ = client
+
+	// This test is more of a unit test for the logic
+	// In a real scenario, you'd mock the HTTP client properly
+	drv := New().(*T)
+	drv.UUID = "test-uuid"
+	drv.Host = "test-host"
+	drv.Permission = "read-write"
+	drv.Endpoint = server.URL
+
+	// Mock the filesAPI
+	// This is simplified - in a real test you'd use dependency injection
+
+	// Test with no clients
+	testNoClients := &FilesystemInfo{
+		UUID:       "test-uuid",
+		NFSClients: []NfsClient{},
+		Status:     "online",
+	}
+
+	// Test the status logic
+	assert.Equal(t, status.Down, drv.fileStatusFromInfo(testNoClients))
+}
+
+// TestFileStatusWithClients tests status when clients are available
+func TestFileStatusWithClients(t *testing.T) {
+	testWithClients := &FilesystemInfo{
+		UUID: "test-uuid",
+		NFSClients: []NfsClient{
+			{UUID: "client1", Host: "test-host", Permission: "read-write", Protocol: "nfs4.1"},
+		},
+		Status: "online",
+	}
+
+	drv := New().(*T)
+	drv.UUID = "test-uuid"
+	drv.Host = "test-host"
+	drv.Permission = "read-write"
+
+	// Test the status logic
+	assert.Equal(t, status.Up, drv.fileStatusFromInfo(testWithClients))
+}
+
+// fileStatusFromInfo is a test helper that simulates fileStatus with a given FilesystemInfo
+func (t *T) fileStatusFromInfo(fileInfo *FilesystemInfo) status.T {
+	if fileInfo == nil {
+		t.StatusLog().Info("file object not visible in api")
+		return status.Down
+	}
+
+	clients := t.getNFSClients(fileInfo)
+	n := len(clients)
+
+	if t.Exclusive {
+		if n > 1 {
+			t.StatusLog().Warn("too many grants (%d)", n)
+		}
+	}
+
+	if n == 0 {
+		t.StatusLog().Info("no access granted")
+		return status.Down
+	}
+
+	// Filter clients to only those matching our host and permission
+	var matchingClients []NfsClient
+	for _, client := range clients {
+		if client.Host == t.Host && client.Permission == t.Permission {
+			matchingClients = append(matchingClients, client)
+		}
+	}
+
+	if len(matchingClients) == 0 {
+		t.StatusLog().Info("access not in current grants")
+		return status.Down
+	}
+
+	if fileInfo.Status == "passive" {
+		t.StatusLog().Info("status passive, access granted")
+		return status.Down
+	}
+
+	return status.Up
+}
+
+// TestLabel tests the label functionality
+func TestLabel(t *testing.T) {
+	drv := newDrvWithRid("test-rid")
+	drv.authInfoer = tCreateAuthInfo("id1")
+
+	drv.UUID = "test-uuid"
+	drv.MountPoint = "/tmp/foo"
+	drv.Device = "/dev/false-nfs-for-test"
+	require.NoError(t, drv.Configure())
+
+	ctx := context.Background()
+	label := drv.Label(ctx)
+
+	// Without an underlying filesystem driver, should return UUID
+	assert.Equal(t, "/dev/false-nfs-for-test@/tmp/foo", label)
+}
+
+// TestManifest tests the manifest functionality
+func TestManifest(t *testing.T) {
+	drv := New().(*T)
+
+	manifest := drv.Manifest()
+	require.NotNil(t, manifest)
+
+	// Should have the correct driver ID
+	assert.Equal(t, drvID, manifest.DriverID)
+
+	// Should have keywords
+	assert.NotEmpty(t, manifest.Keywords)
+}
+
+// TestFilesystemInfoUnmarshal tests JSON unmarshaling of FilesystemInfo
+func TestFilesystemInfoUnmarshal(t *testing.T) {
+	jsonData := `{
+		"uuid": "test-uuid",
+		"consistencyGroupId": "cg-uuid",
+		"nfsClients": [
+			{"uuid": "client1", "host": "host1", "permission": "read-write", "protocol": "nfs4.1"}
+		],
+		"status": "online"
+	}`
+
+	var fileInfo FilesystemInfo
+	err := json.Unmarshal([]byte(jsonData), &fileInfo)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-uuid", fileInfo.UUID)
+	assert.Equal(t, "cg-uuid", fileInfo.ConsistencyGroupID)
+	assert.Len(t, fileInfo.NFSClients, 1)
+	assert.Equal(t, "host1", fileInfo.NFSClients[0].Host)
+	assert.Equal(t, "read-write", fileInfo.NFSClients[0].Permission)
+}
+
+// TestNfsClientMarshal tests JSON marshaling of NfsClient
+func TestNfsClientMarshal(t *testing.T) {
+	client := NfsClient{
+		UUID:       "client-uuid",
+		Host:       "client-host",
+		Permission: "read-write",
+		Protocol:   "nfs4.1",
+	}
+
+	jsonData, err := json.Marshal(client)
+	require.NoError(t, err)
+
+	var unmarshaled NfsClient
+	err = json.Unmarshal(jsonData, &unmarshaled)
+	require.NoError(t, err)
+
+	assert.Equal(t, client.UUID, unmarshaled.UUID)
+	assert.Equal(t, client.Host, unmarshaled.Host)
+	assert.Equal(t, client.Permission, unmarshaled.Permission)
+	assert.Equal(t, client.Protocol, unmarshaled.Protocol)
+}

--- a/drivers/resfssgcp_nfs/manifest.go
+++ b/drivers/resfssgcp_nfs/manifest.go
@@ -1,0 +1,90 @@
+package resfssgcp_nfs
+
+import (
+	"embed"
+
+	"github.com/opensvc/om3/v3/core/datarecv"
+	"github.com/opensvc/om3/v3/core/driver"
+	"github.com/opensvc/om3/v3/core/keywords"
+	"github.com/opensvc/om3/v3/core/manifest"
+	"github.com/opensvc/om3/v3/core/naming"
+)
+
+var (
+	//go:embed text
+	fs embed.FS
+
+	drvID = driver.NewID(driver.GroupFS, "sgcp_nfs")
+
+	kws = []*keywords.Keyword{
+		{
+			Attr:     "UUID",
+			Option:   "uuid",
+			Required: true,
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/uuid"),
+		},
+		{
+			Attr:     "Host",
+			Option:   "host",
+			Required: true,
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/host"),
+		},
+		{
+			Attr:       "Permission",
+			Option:     "permission",
+			Candidates: []string{"read-only", "read-write"},
+			Default:    DefaultPermission,
+			Scopable:   true,
+			Text:       keywords.NewText(fs, "text/kw/permission"),
+		},
+		{
+			Attr:      "Exclusive",
+			Option:    "exclusive",
+			Converter: "boolean",
+			Default:   "false", // TODO: move to config
+			Scopable:  true,
+			Text:      keywords.NewText(fs, "text/kw/exclusive"),
+		},
+		{
+			Attr:       "Protocol",
+			Option:     "protocol",
+			Candidates: []string{"nfs4.1"},
+			Default:    DefaultProtocol, // TODO: move to config
+			Scopable:   true,
+			Text:       keywords.NewText(fs, "text/kw/protocol"),
+		},
+		{
+			Attr:     "Secret",
+			Option:   "secret",
+			Default:  SecretDefaultName,
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/secret"),
+		},
+		{
+			Attr:     "Endpoint",
+			Option:   "endpoint",
+			Default:  "https://localhost/v1", // TODO: move to config
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/endpoint"),
+		},
+	}
+)
+
+func init() {
+	driver.Register(drvID, New)
+}
+
+func (t *T) DriverID() driver.ID {
+	return drvID
+}
+
+// Manifest exposes to the core the input expected by the driver.
+func (t *T) Manifest() *manifest.T {
+	m := manifest.New(drvID, t)
+	m.Kinds.Or(naming.KindSvc, naming.KindVol)
+	m.AddKeywords(kws...)
+	m.AddKeywords(datarecv.Keywords("DataRecv.")...)
+	return m
+}

--- a/drivers/resfssgcp_nfs/manifest.go
+++ b/drivers/resfssgcp_nfs/manifest.go
@@ -8,6 +8,14 @@ import (
 	"github.com/opensvc/om3/v3/core/keywords"
 	"github.com/opensvc/om3/v3/core/manifest"
 	"github.com/opensvc/om3/v3/core/naming"
+	"github.com/opensvc/om3/v3/drivers/resfshost"
+)
+
+const (
+	DefaultPermission = "read-write"
+	DefaultProtocol   = "nfs4.1"
+	DefaultExclusive  = "false"
+	SecretDefaultName = "iam"
 )
 
 var (
@@ -42,8 +50,8 @@ var (
 		{
 			Attr:      "Exclusive",
 			Option:    "exclusive",
-			Converter: "boolean",
-			Default:   "false", // TODO: move to config
+			Converter: "bool",
+			Default:   DefaultExclusive,
 			Scopable:  true,
 			Text:      keywords.NewText(fs, "text/kw/exclusive"),
 		},
@@ -65,7 +73,6 @@ var (
 		{
 			Attr:     "Endpoint",
 			Option:   "endpoint",
-			Default:  "https://localhost/v1", // TODO: move to config
 			Scopable: true,
 			Text:     keywords.NewText(fs, "text/kw/endpoint"),
 		},
@@ -85,6 +92,14 @@ func (t *T) Manifest() *manifest.T {
 	m := manifest.New(drvID, t)
 	m.Kinds.Or(naming.KindSvc, naming.KindVol)
 	m.AddKeywords(kws...)
+	m.AddKeywords(
+		&resfshost.KeywordDevice,
+		&resfshost.KeywordMountPoint,
+		&resfshost.KeywordMountOptions,
+		&resfshost.KeywordStatTimeout,
+		&resfshost.KeywordZone,
+		&resfshost.KeywordCheckReadEnabled,
+	)
 	m.AddKeywords(datarecv.Keywords("DataRecv.")...)
 	return m
 }

--- a/drivers/resfssgcp_nfs/manifest.go
+++ b/drivers/resfssgcp_nfs/manifest.go
@@ -9,6 +9,8 @@ import (
 	"github.com/opensvc/om3/v3/core/manifest"
 	"github.com/opensvc/om3/v3/core/naming"
 	"github.com/opensvc/om3/v3/drivers/resfshost"
+	"github.com/opensvc/om3/v3/util/file"
+	"github.com/opensvc/om3/v3/util/sgcp"
 )
 
 const (
@@ -80,7 +82,9 @@ var (
 )
 
 func init() {
-	driver.Register(drvID, New)
+	if file.Exists(sgcp.DefaultConfigPath) {
+		driver.Register(drvID, New)
+	}
 }
 
 func (t *T) DriverID() driver.ID {

--- a/drivers/resfssgcp_nfs/text/kw/endpoint
+++ b/drivers/resfssgcp_nfs/text/kw/endpoint
@@ -1,0 +1,1 @@
+The api url to use for filesystem management.

--- a/drivers/resfssgcp_nfs/text/kw/exclusive
+++ b/drivers/resfssgcp_nfs/text/kw/exclusive
@@ -1,0 +1,1 @@
+If exclusive, on start, drop all grants for other hosts on the filesystem.

--- a/drivers/resfssgcp_nfs/text/kw/host
+++ b/drivers/resfssgcp_nfs/text/kw/host
@@ -1,0 +1,1 @@
+The client ip address or resolvable name granted access to the filesystem on start.

--- a/drivers/resfssgcp_nfs/text/kw/permission
+++ b/drivers/resfssgcp_nfs/text/kw/permission
@@ -1,0 +1,1 @@
+The access permission on the filesystem granted to the host.

--- a/drivers/resfssgcp_nfs/text/kw/protocol
+++ b/drivers/resfssgcp_nfs/text/kw/protocol
@@ -1,0 +1,1 @@
+The protocol used to access the filesystem.

--- a/drivers/resfssgcp_nfs/text/kw/secret
+++ b/drivers/resfssgcp_nfs/text/kw/secret
@@ -1,0 +1,1 @@
+The name of the secret object in the same namespace containing the api access credentials.

--- a/drivers/resfssgcp_nfs/text/kw/uuid
+++ b/drivers/resfssgcp_nfs/text/kw/uuid
@@ -1,0 +1,1 @@
+The unique identifier of the filesystem object on the provider.

--- a/drivers/resfssgcp_nfs_cg/caps.go
+++ b/drivers/resfssgcp_nfs_cg/caps.go
@@ -1,0 +1,15 @@
+package resfssgcp_nfs_cg
+
+import (
+	"context"
+
+	"github.com/opensvc/om3/v3/util/capabilities"
+)
+
+func init() {
+	capabilities.Register(capabilitiesScanner)
+}
+
+func capabilitiesScanner(ctx context.Context) ([]string, error) {
+	return []string{drvID.Cap()}, nil
+}

--- a/drivers/resfssgcp_nfs_cg/manifest.go
+++ b/drivers/resfssgcp_nfs_cg/manifest.go
@@ -1,0 +1,80 @@
+package resfssgcp_nfs_cg
+
+import (
+	"embed"
+
+	"github.com/opensvc/om3/v3/core/driver"
+	"github.com/opensvc/om3/v3/core/keywords"
+	"github.com/opensvc/om3/v3/core/manifest"
+	"github.com/opensvc/om3/v3/core/naming"
+)
+
+var (
+	//go:embed text
+	fs embed.FS
+
+	drvID = driver.NewID(driver.GroupFS, "sgcp_nfs_cg")
+
+	kws = []*keywords.Keyword{
+		{
+			Attr:     "UUID",
+			Option:   "uuid",
+			Required: true,
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/uuid"),
+		},
+		{
+			Attr:     "AZ",
+			Option:   "az",
+			Default:  "{node.labels.az}",
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/az"),
+		},
+		{
+			Attr:     "Secret",
+			Option:   "secret",
+			Default:  SecretDefaultName,
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/secret"),
+		},
+		{
+			Attr:     "Endpoint",
+			Option:   "endpoint",
+			Default:  "https://localhost/v1", // TODO: move to config
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/endpoint"),
+		},
+		{
+			Attr:      "Timeout",
+			Option:    "timeout",
+			Converter: "duration",
+			Default:   "300s", // TODO: move to config
+			Scopable:  true,
+			Text:      keywords.NewText(fs, "text/kw/timeout"),
+		},
+		{
+			Attr:      "Failover",
+			Option:    "failover",
+			Converter: "boolean",
+			Default:   "true",
+			Scopable:  true,
+			Text:      keywords.NewText(fs, "text/kw/failover"),
+		},
+	}
+)
+
+func init() {
+	driver.Register(drvID, New)
+}
+
+func (t *T) DriverID() driver.ID {
+	return drvID
+}
+
+// Manifest exposes to the core the input expected by the driver.
+func (t *T) Manifest() *manifest.T {
+	m := manifest.New(drvID, t)
+	m.Kinds.Or(naming.KindSvc, naming.KindVol)
+	m.AddKeywords(kws...)
+	return m
+}

--- a/drivers/resfssgcp_nfs_cg/text/kw/az
+++ b/drivers/resfssgcp_nfs_cg/text/kw/az
@@ -1,0 +1,1 @@
+The availability zone of the local node. Use a reference to a node label or a scoped value.

--- a/drivers/resfssgcp_nfs_cg/text/kw/endpoint
+++ b/drivers/resfssgcp_nfs_cg/text/kw/endpoint
@@ -1,0 +1,1 @@
+The fileaas api url.

--- a/drivers/resfssgcp_nfs_cg/text/kw/failover
+++ b/drivers/resfssgcp_nfs_cg/text/kw/failover
@@ -1,0 +1,2 @@
+Allows daemon resource start to call operation 'switchover' when the 'failover' operation fails with status code 412.
+When '--force' option is used, the setting has no effect because operation during start is always 'failover'.

--- a/drivers/resfssgcp_nfs_cg/text/kw/secret
+++ b/drivers/resfssgcp_nfs_cg/text/kw/secret
@@ -1,0 +1,1 @@
+The name of the secret object in the same namespace containing the api access credentials.

--- a/drivers/resfssgcp_nfs_cg/text/kw/timeout
+++ b/drivers/resfssgcp_nfs_cg/text/kw/timeout
@@ -1,0 +1,1 @@
+The maximum time to wait for a consistency group switchover.

--- a/drivers/resfssgcp_nfs_cg/text/kw/uuid
+++ b/drivers/resfssgcp_nfs_cg/text/kw/uuid
@@ -1,0 +1,1 @@
+The fileaas consistency group id.

--- a/drivers/resipsgcp_dnsalias/caps.go
+++ b/drivers/resipsgcp_dnsalias/caps.go
@@ -1,0 +1,15 @@
+package resipsgcp_dnsalias
+
+import (
+	"context"
+
+	"github.com/opensvc/om3/v3/util/capabilities"
+)
+
+func init() {
+	capabilities.Register(capabilitiesScanner)
+}
+
+func capabilitiesScanner(ctx context.Context) ([]string, error) {
+	return []string{drvID.Cap()}, nil
+}

--- a/drivers/resipsgcp_dnsalias/manifest.go
+++ b/drivers/resipsgcp_dnsalias/manifest.go
@@ -48,14 +48,12 @@ var (
 		{
 			Attr:     "Secret",
 			Option:   "secret",
-			Default:  SecretDefaultName,
 			Scopable: true,
 			Text:     keywords.NewText(fs, "text/kw/secret"),
 		},
 		{
 			Attr:     "Endpoint",
 			Option:   "endpoint",
-			Default:  "https://localhost/v1", // TODO: move to config
 			Scopable: true,
 			Text:     keywords.NewText(fs, "text/kw/endpoint"),
 		},

--- a/drivers/resipsgcp_dnsalias/manifest.go
+++ b/drivers/resipsgcp_dnsalias/manifest.go
@@ -1,0 +1,79 @@
+package resipsgcp_dnsalias
+
+import (
+	"embed"
+
+	"github.com/opensvc/om3/v3/core/driver"
+	"github.com/opensvc/om3/v3/core/keywords"
+	"github.com/opensvc/om3/v3/core/manifest"
+	"github.com/opensvc/om3/v3/core/naming"
+)
+
+var (
+	//go:embed text
+	fs embed.FS
+
+	drvID = driver.NewID(driver.GroupIP, "sgcp_dnsalias")
+
+	kws = []*keywords.Keyword{
+		{
+			Attr:     "UUID",
+			Option:   "uuid",
+			Required: false,
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/uuid"),
+		},
+		{
+			Attr:     "Name",
+			Option:   "name",
+			Required: false,
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/name"),
+		},
+		{
+			Attr:        "Target",
+			Option:      "target",
+			Required:    false,
+			Scopable:    true,
+			DefaultText: keywords.NewText(fs, "text/kw/target_default"),
+			Text:        keywords.NewText(fs, "text/kw/target"),
+		},
+		{
+			Attr:     "ZoneID",
+			Option:   "zone_id",
+			Required: true,
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/zone_id"),
+		},
+		{
+			Attr:     "Secret",
+			Option:   "secret",
+			Default:  SecretDefaultName,
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/secret"),
+		},
+		{
+			Attr:     "Endpoint",
+			Option:   "endpoint",
+			Default:  "https://localhost/v1", // TODO: move to config
+			Scopable: true,
+			Text:     keywords.NewText(fs, "text/kw/endpoint"),
+		},
+	}
+)
+
+func init() {
+	driver.Register(drvID, New)
+}
+
+func (t *T) DriverID() driver.ID {
+	return drvID
+}
+
+// Manifest exposes to the core the input expected by the driver.
+func (t *T) Manifest() *manifest.T {
+	m := manifest.New(drvID, t)
+	m.Kinds.Or(naming.KindSvc, naming.KindVol)
+	m.AddKeywords(kws...)
+	return m
+}

--- a/drivers/resipsgcp_dnsalias/text/kw/endpoint
+++ b/drivers/resipsgcp_dnsalias/text/kw/endpoint
@@ -1,0 +1,1 @@
+The api url to use for DNS alias management.

--- a/drivers/resipsgcp_dnsalias/text/kw/name
+++ b/drivers/resipsgcp_dnsalias/text/kw/name
@@ -1,0 +1,1 @@
+The DNS alias name to control. If set, ensure alias name is correct during start, or check.

--- a/drivers/resipsgcp_dnsalias/text/kw/secret
+++ b/drivers/resipsgcp_dnsalias/text/kw/secret
@@ -1,0 +1,1 @@
+The name of the secret object in the same namespace containing the api access credentials.

--- a/drivers/resipsgcp_dnsalias/text/kw/target
+++ b/drivers/resipsgcp_dnsalias/text/kw/target
@@ -1,0 +1,1 @@
+The DNS record name to point the alias to.

--- a/drivers/resipsgcp_dnsalias/text/kw/target.default
+++ b/drivers/resipsgcp_dnsalias/text/kw/target.default
@@ -1,0 +1,1 @@
+The node hostname

--- a/drivers/resipsgcp_dnsalias/text/kw/uuid
+++ b/drivers/resipsgcp_dnsalias/text/kw/uuid
@@ -1,0 +1,3 @@
+The DNS alias uuid to control. If set, the stop does not delete the DNS API object,
+but sets 'none.' as the target instead.
+If not set, the start tries to detect uuid to update, or create new one, the stop delete alias with name.

--- a/drivers/resipsgcp_dnsalias/text/kw/zone_id
+++ b/drivers/resipsgcp_dnsalias/text/kw/zone_id
@@ -1,0 +1,1 @@
+The DNS zone identifier.

--- a/drivers/sgcphelper/main.go
+++ b/drivers/sgcphelper/main.go
@@ -1,0 +1,39 @@
+package sgcphelper
+
+import (
+	"fmt"
+
+	"github.com/opensvc/om3/v3/core/naming"
+	"github.com/opensvc/om3/v3/core/object"
+	"github.com/opensvc/om3/v3/util/sgcp"
+)
+
+// GetAuthInfo retrieves authentication information from the specified datastore path and returns an AuthInfo struct.
+func GetAuthInfo(datastorePath string) (*sgcp.AuthInfo, error) {
+	var (
+		ds       object.DataStore
+		dsValues [][]byte
+	)
+	secPath, err := naming.ParsePath(datastorePath)
+	if err != nil {
+		return nil, fmt.Errorf("parse secret path: %w", err)
+	}
+
+	ds, err = object.NewSec(secPath, object.WithVolatile(true))
+	if err != nil {
+		return nil, fmt.Errorf("get secret %s: %w", secPath, err)
+	}
+
+	dsValues, err = ds.DecodeKeys("account_id", "client_id", "client_secret")
+	if err != nil {
+		return nil, fmt.Errorf("decode auth keys from %s: %w", secPath, err)
+	}
+	authInfo := &sgcp.AuthInfo{
+		AccountID:    string(dsValues[0]),
+		ClientID:     string(dsValues[1]),
+		ClientSecret: string(dsValues[2]),
+
+		Signature: fmt.Sprintf("sgcp-authinfo-%s-%s", secPath.Namespace, secPath.Name),
+	}
+	return authInfo, nil
+}

--- a/drivers/sgcphelper/main.go
+++ b/drivers/sgcphelper/main.go
@@ -8,8 +8,12 @@ import (
 	"github.com/opensvc/om3/v3/util/sgcp"
 )
 
+type (
+	GetAuthInfoFromDatastorePather struct{}
+)
+
 // GetAuthInfo retrieves authentication information from the specified datastore path and returns an AuthInfo struct.
-func GetAuthInfo(datastorePath string) (*sgcp.AuthInfo, error) {
+func (g *GetAuthInfoFromDatastorePather) GetAuthInfo(datastorePath string) (*sgcp.AuthInfo, error) {
 	var (
 		ds       object.DataStore
 		dsValues [][]byte

--- a/util/ageingcache/main.go
+++ b/util/ageingcache/main.go
@@ -7,11 +7,26 @@ import (
 	"github.com/opensvc/fcache"
 	"github.com/opensvc/fcntllock"
 	"github.com/opensvc/flock"
+
 	"github.com/opensvc/om3/v3/core/rawconfig"
 	"github.com/opensvc/om3/v3/util/xsession"
 )
 
 var maxLockDuration = 30 * time.Second
+
+type (
+	Outputter struct {
+		f func() ([]byte, error)
+	}
+)
+
+func NewOutputter(f func() ([]byte, error)) *Outputter {
+	return &Outputter{f: f}
+}
+
+func (t *Outputter) Output() ([]byte, error) {
+	return t.f()
+}
 
 // Output manage output session function cache
 func Output(o fcache.Outputter, sig string, maxAge time.Duration) (out []byte, err error) {

--- a/util/file/main.go
+++ b/util/file/main.go
@@ -10,8 +10,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/opensvc/om3/v3/util/command"
 	"golang.org/x/sys/unix"
+
+	"github.com/opensvc/om3/v3/util/command"
 )
 
 var (
@@ -342,16 +343,16 @@ func VerifySameMajorMinorAndInode(p1, p2 string) error {
 		return err
 	}
 
-	maj1 := unix.Major(stat1.Rdev)
-	maj2 := unix.Major(stat2.Rdev)
+	maj1 := unix.Major(uint64(stat1.Rdev))
+	maj2 := unix.Major(uint64(stat2.Rdev))
 	if maj1 != maj2 {
 		return fmt.Errorf("%w: major of %s is %d, %s is %d",
 			ErrNotSame, p1, maj1, p2, maj2,
 		)
 	}
 
-	min1 := unix.Minor(stat1.Rdev)
-	min2 := unix.Minor(stat2.Rdev)
+	min1 := unix.Minor(uint64(stat1.Rdev))
+	min2 := unix.Minor(uint64(stat2.Rdev))
 	if min1 != min2 {
 		return fmt.Errorf("%w: minor of %s is %d, %s is %d",
 			ErrNotSame, p1, min1, p2, min2,

--- a/util/pg/dummy.go
+++ b/util/pg/dummy.go
@@ -3,8 +3,8 @@
 package pg
 
 // ApplyProc creates the cgroup, set caps, and add the specified process
-func (c Config) ApplyProc(pid int) error {
-	return nil
+func (c Config) ApplyProc(pid int) (bool, error) {
+	return false, nil
 }
 
 func (c Config) Delete() (bool, error) {

--- a/util/sgcp/api.go
+++ b/util/sgcp/api.go
@@ -1,0 +1,67 @@
+package sgcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+
+	"github.com/opensvc/om3/v3/util/plog"
+)
+
+type (
+	Api struct {
+		client *http.Client
+		tk     tokenGetter
+		log    *plog.Logger
+	}
+
+	tokenGetter interface {
+		Get(ctx context.Context, scope ...string) (string, error)
+	}
+)
+
+func (a *Api) CheckStatusCode(method, url string, got int, wanted ...int) error {
+	a.log.Debugf("%s %s status code: %d", method, url, got)
+	if slices.Contains(wanted, got) {
+		return nil
+	}
+	return fmt.Errorf("unexpected status code for %s %s got %d wanted %v", method, url, got, wanted)
+}
+
+func (a *Api) do(ctx context.Context, method, url string, body io.Reader, scopes ...string) (statusCode int, b []byte, err error) {
+	var req *http.Request
+	var resp *http.Response
+
+	bearer, err := a.tk.Get(ctx, scopes...)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	req, err = http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	// Add headers for authentication
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearer))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	a.log.Debugf("request: %s %s", method, url)
+	resp, err = a.client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	a.log.Debugf("request: %s %s status code: %d", method, url, resp.StatusCode)
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	b, err = io.ReadAll(resp.Body)
+
+	return resp.StatusCode, b, err
+}

--- a/util/sgcp/api_test.go
+++ b/util/sgcp/api_test.go
@@ -1,0 +1,100 @@
+package sgcp
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opensvc/om3/v3/util/plog"
+)
+
+type (
+	TTkBuilder struct{}
+)
+
+func (ttk *TTkBuilder) Get(ctx context.Context, scope ...string) (string, error) {
+	return "tk_scopes=" + strings.Join(scope, ","), nil
+}
+
+func TestDo(t *testing.T) {
+	defer Setup(t)()
+	InstallConfig(t)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	// Create a test server
+	var calls []string
+
+	validAuth := "Bearer tk_scopes=scope1,scope2"
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/foo/bar" && r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/json")
+			auth := r.Header.Get("Authorization")
+			if auth != validAuth {
+				t.Logf("invalid auth %s instead of %s", auth, validAuth)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			t.Logf("%s %s auth %s", r.Method, r.URL.Path, auth)
+			w.WriteHeader(http.StatusOK)
+			calls = append(calls, "test")
+			enc := json.NewEncoder(w)
+			enc.Encode(map[string]interface{}{"test": calls})
+			return
+		}
+	})
+
+	ts := httptest.NewUnstartedServer(handler)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:1215")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts.EnableHTTP2 = true
+	ts.Listener = ln
+	ts.StartTLS()
+	defer ts.Close()
+
+	client := ts.Client()
+	log := plog.NewDefaultLogger()
+
+	api := Api{
+		client: client,
+		log:    log,
+		tk:     &TTkBuilder{},
+	}
+
+	ctx := context.Background()
+
+	// First request should hit the server
+	code, data1, err := api.do(ctx, "GET", "https://127.0.0.1:1215/foo/bar", nil, "scope1", "scope2")
+	require.Equal(t, 200, code)
+	require.NoError(t, err)
+	t.Logf("First request result: %s", string(data1))
+	assert.Equal(t, string([]byte(`{"test":["test"]}`)), strings.TrimSuffix(string(data1), "\n"))
+}
+
+// TestCheckStatusCode tests the status code checking
+func TestCheckStatusCode(t *testing.T) {
+	a := &Api{
+		log: plog.NewDefaultLogger(),
+	}
+
+	err := a.CheckStatusCode(http.MethodGet, "https://localhost:1215/foo", 403, 200, 201)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status code for GET https://localhost:1215/foo got 403 wanted [200 201]")
+
+	err = a.CheckStatusCode(http.MethodGet, "https://localhost:1215/foo", 201, 200, 201)
+	assert.Nil(t, err)
+}

--- a/util/sgcp/auth.go
+++ b/util/sgcp/auth.go
@@ -1,0 +1,13 @@
+package sgcp
+
+type (
+	// AuthInfo represents authentication details required for API access.
+	AuthInfo struct {
+		AccountID    string
+		ClientID     string
+		ClientSecret string
+
+		// Signature identifies auth info
+		Signature string
+	}
+)

--- a/util/sgcp/auth.go
+++ b/util/sgcp/auth.go
@@ -1,5 +1,19 @@
 package sgcp
 
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/opensvc/om3/v3/util/ageingcache"
+	"github.com/opensvc/om3/v3/util/plog"
+)
+
 type (
 	// AuthInfo represents authentication details required for API access.
 	AuthInfo struct {
@@ -10,4 +24,142 @@ type (
 		// Signature identifies auth info
 		Signature string
 	}
+
+	// TokenFactory is responsible for generating and caching authentication tokens for API access.
+	TokenFactory struct {
+		authInfo   *AuthInfo
+		authConfig *AuthConfig
+		log        *plog.Logger
+		client     *http.Client
+	}
+
+	// Token represents an authentication token used for API access.
+	Token struct {
+		AccessToken string `json:"access_token"`
+		Scope       string `json:"scope,omitempty"`
+		TokenType   string `json:"token_type,omitempty"`
+		ExpiresIn   int    `json:"expires_in,omitempty"`
+	}
 )
+
+// NewTokenFactory initializes a new instance of TokenFactory with the provided logger, authentication config, and auth info.
+func NewTokenFactory(log *plog.Logger, client *http.Client, authCfg *AuthConfig, authInfo *AuthInfo) *TokenFactory {
+	return &TokenFactory{
+		client:     client,
+		log:        log,
+		authConfig: authCfg,
+		authInfo:   authInfo,
+	}
+}
+
+// Get retrieves an authentication token for the given context and scopes, utilizing caching for performance optimization.
+// Returns the token as a string or an error if retrieval fails.
+func (t *TokenFactory) Get(ctx context.Context, scope ...string) (string, error) {
+	cacheMaxAge := time.Duration(t.authConfig.TTLSeconds) * time.Second
+	sig := t.signature(scope...)
+	o := ageingcache.NewOutputter(func() ([]byte, error) {
+		token, err := t.newToken(ctx, scope...)
+		if err != nil {
+			t.log.Debugf("get token failed on missing cache sig %s.out, ttl: %s", sig, cacheMaxAge)
+			return nil, fmt.Errorf("get token failed: %w", err)
+		}
+		return []byte(token.AccessToken), nil
+	})
+	data, err := ageingcache.Output(o, sig, cacheMaxAge)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// Clear removes the cached authentication token associated with the provided scope(s).
+// Returns an error if the operation fails.
+func (t *TokenFactory) Clear(scope ...string) error {
+
+	return ageingcache.Clear(t.signature(scope...))
+}
+
+// newToken generates a new authentication token for the provided context and scope(s) using client credentials flow.
+func (t *TokenFactory) newToken(ctx context.Context, scope ...string) (*Token, error) {
+	if t.authConfig.BaseURL == "" {
+		return nil, fmt.Errorf("empty auth config BaseURL")
+	}
+	if t.authInfo.ClientID == "" || t.authInfo.ClientSecret == "" {
+		return nil, fmt.Errorf("client_id and client_secret are required")
+	}
+	if len(scope) == 0 {
+		return nil, fmt.Errorf("scope is required")
+	}
+
+	requestURL := strings.TrimRight(t.authConfig.BaseURL, "/") + "/access_token"
+	values := url.Values{}
+	values.Set("grant_type", "client_credentials")
+	scopes := t.formatScopeRequest(scope...)
+	values.Set("scope", scopes)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(t.authInfo.ClientID, t.authInfo.ClientSecret)
+
+	//client := &http.Client{Timeout: time.Duration(max(1, t.authConfig.Timeout)) * time.Second}
+	//t.client
+	client := *t.client
+	client.Timeout = time.Duration(max(1, t.authConfig.Timeout)) * time.Second
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("iam token request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var token Token
+	if err := json.NewDecoder(resp.Body).Decode(&token); err != nil {
+		return nil, err
+	}
+	if token.AccessToken == "" {
+		return nil, fmt.Errorf("iam token response missing access_token")
+	}
+	return &token, nil
+}
+
+// signature returns a sanitized signature for the scopes.
+func (t *TokenFactory) signature(scope ...string) string {
+	sanitize := func(a ...string) string {
+		var l []string
+		for _, s := range a {
+			sanitized := strings.Map(func(r rune) rune {
+				if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+					return r
+				}
+				return '-'
+			}, s)
+			l = append(l, sanitized)
+		}
+		return strings.Join(l, "-")
+	}
+
+	l := append([]string{}, t.authInfo.Signature)
+	l = append(l, scope...)
+
+	return fmt.Sprintf("sgcp-token-%s", sanitize(l...))
+}
+
+// formatScopeRequest constructs a formatted scope string that can be used to request new token,
+// by prepending the account ID if it's not empty and processing each scope.
+func (t *TokenFactory) formatScopeRequest(scopes ...string) string {
+	if t.authInfo.AccountID == "" {
+		return strings.Join(scopes, " ")
+	}
+	out := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		out = append(out, t.authInfo.AccountID+":"+scope)
+	}
+	return strings.Join(out, " ")
+}

--- a/util/sgcp/auth_test.go
+++ b/util/sgcp/auth_test.go
@@ -1,0 +1,129 @@
+package sgcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/opensvc/om3/v3/util/plog"
+)
+
+func TestTokenFactory(t *testing.T) {
+	defer Setup(t)()
+	InstallConfig(t)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	// Create a test server
+	var authCalls []string
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		type bodyStruct struct {
+			Scope string
+		}
+
+		if r.URL.Path == "/auth/access_token" && r.Method == "POST" {
+			w.Header().Set("Content-Type", "application/json")
+			auth := r.Header.Get("Authorization")
+			basicAuth, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
+			require.NoError(t, err)
+			if string(basicAuth) != "clientid1:clientSecret1" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			l := strings.Split(string(basicAuth), ":")
+
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			scope := r.FormValue("scope")
+
+			t.Logf("Read %s bytes from request body", string(scope))
+			w.WriteHeader(http.StatusOK)
+			t.Logf("Post new token for for client id: %s", l[0])
+			authCalls = append(authCalls, l[0]+":"+scope)
+			enc := json.NewEncoder(w)
+			enc.Encode(map[string]interface{}{
+				"access_token": l[0] + ":" + scope,
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	ts := httptest.NewUnstartedServer(handler)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:1215")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts.EnableHTTP2 = true
+	ts.Listener = ln
+	ts.StartTLS()
+	defer ts.Close()
+
+	authInfo := &AuthInfo{
+		AccountID:    "account1",
+		ClientID:     "clientid1",
+		ClientSecret: "clientSecret1",
+		Signature:    "the-secret",
+	}
+	client := ts.Client()
+	log := plog.NewDefaultLogger()
+	tk := NewTokenFactory(log, client, &cfg.Auth, authInfo)
+	ctx := context.Background()
+
+	require.NoError(t, tk.Clear("scope1"))
+	require.NoError(t, tk.Clear("scope2", "scope3"))
+
+	callSignScope1 := "clientid1:account1:scope1"
+	callSignScope2and3 := "clientid1:account1:scope2 account1:scope3"
+
+	t.Logf("get token for scope1")
+	bearer, err := tk.Get(ctx, "scope1")
+	require.NoError(t, err)
+	require.Equal(t, "clientid1:account1:scope1", bearer)
+	expectedCalls := []string{callSignScope1}
+	require.Equal(t, expectedCalls, authCalls)
+
+	t.Logf("get again token for scope1, must hit cache")
+	bearer, err = tk.Get(ctx, "scope1")
+	require.NoError(t, err)
+	require.Equal(t, "clientid1:account1:scope1", bearer)
+	expectedCalls = []string{callSignScope1}
+	require.Equalf(t, expectedCalls, authCalls, "The second call didn't hit cache")
+
+	t.Logf("get again token for scope2 and scope3")
+	bearer, err = tk.Get(ctx, "scope2", "scope3")
+	require.NoError(t, err)
+	require.Equal(t, "clientid1:account1:scope2 account1:scope3", bearer)
+	expectedCalls = []string{callSignScope1, callSignScope2and3}
+	require.Equalf(t, expectedCalls, authCalls, "wanted calls %v, got %v", expectedCalls, authCalls)
+
+	t.Logf("get again token for scope1, must hit cache")
+	bearer, err = tk.Get(ctx, "scope1")
+	require.NoError(t, err)
+	require.Equal(t, "clientid1:account1:scope1", bearer)
+	expectedCalls = []string{callSignScope1, callSignScope2and3}
+	require.Equalf(t, expectedCalls, authCalls, "wanted calls %v, got %v", expectedCalls, authCalls)
+
+	t.Logf("clear cache scope1")
+	require.NoError(t, tk.Clear("scope1"))
+	t.Logf("get again token for scope1, must create new token")
+	bearer, err = tk.Get(ctx, "scope1")
+	require.NoError(t, err)
+	require.Equal(t, "clientid1:account1:scope1", bearer)
+	expectedCalls = []string{callSignScope1, callSignScope2and3, callSignScope1}
+	require.Equalf(t, expectedCalls, authCalls, "wanted calls %v, got %v", expectedCalls, authCalls)
+}

--- a/util/sgcp/config.go
+++ b/util/sgcp/config.go
@@ -13,10 +13,11 @@ import (
 type (
 	// Config represents the SGCP configuration structure
 	Config struct {
-		Files FilesConfig `yaml:"files"`
-		DNS   DNSConfig   `yaml:"dns"`
-		Auth  AuthConfig  `yaml:"auth"`
-		Cache CacheConfig `yaml:"cache"`
+		Files        FilesConfig `yaml:"files"`
+		DNS          DNSConfig   `yaml:"dns"`
+		Auth         AuthConfig  `yaml:"auth"`
+		Cache        CacheConfig `yaml:"cache"`
+		DisabledFlag string      `yaml:"disabled_flag"`
 	}
 
 	// FilesConfig contains file-related API configuration

--- a/util/sgcp/config.go
+++ b/util/sgcp/config.go
@@ -1,0 +1,143 @@
+package sgcp
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/opensvc/om3/v3/util/plog"
+)
+
+type (
+	// Config represents the SGCP configuration structure
+	Config struct {
+		Files FilesConfig `yaml:"files"`
+		DNS   DNSConfig   `yaml:"dns"`
+		Auth  AuthConfig  `yaml:"auth"`
+		Cache CacheConfig `yaml:"cache"`
+	}
+
+	// FilesConfig contains file-related API configuration
+	FilesConfig struct {
+		BaseURL string `yaml:"base_url"`
+		Path    struct {
+			FS     string `yaml:"fs"`
+			Client string `yaml:"client"`
+			CG     string `yaml:"cg"`
+		} `yaml:"path"`
+	}
+
+	// DNSConfig contains DNS-related API configuration
+	DNSConfig struct {
+		BaseURL string `yaml:"base_url"`
+		Path    struct {
+			Alias string `yaml:"alias"`
+			Zone  string `yaml:"zone"`
+		} `yaml:"path"`
+	}
+
+	// AuthConfig contains authentication configuration
+	AuthConfig struct {
+		BaseURL       string              `yaml:"base_url" json:"base_url"`
+		DefaultSecret string              `yaml:"default_secret"`
+		Scopes        map[string][]string `yaml:"scopes"`
+		TTLSeconds    int                 `yaml:"ttl_seconds"`
+		Timeout       int                 `yaml:"timeout"`
+	}
+
+	// CacheConfig contains caching configuration
+	CacheConfig struct {
+		TTLSeconds int  `yaml:"ttl_seconds"`
+		Enabled    bool `yaml:"enabled"`
+	}
+)
+
+// SGCPConfig is the global configuration instance
+var (
+	config     *Config
+	configOnce sync.Once
+	logger     = plog.NewDefaultLogger()
+
+	DefaultConfigPath = "/etc/om3/sgcp.yaml"
+)
+
+const (
+	DefaultBaseURL = "https://localhost/file/v1"
+)
+
+// LoadConfig loads the SGCP configuration
+func LoadConfig() (*Config, error) {
+	data, err := os.ReadFile(DefaultConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file %s: %w", DefaultConfigPath, err)
+	}
+
+	var config Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file %s: %w", DefaultConfigPath, err)
+	}
+
+	return &config, nil
+}
+
+// GetConfig returns the global SGCP configuration, loading it once
+func GetConfig() *Config {
+	configOnce.Do(func() {
+		var err error
+		config, err = LoadConfig()
+		if err != nil {
+			logger.Debugf("Failed to load SGCP config: %v", err)
+		}
+	})
+
+	return config.Clone()
+}
+
+func (c *Config) Clone() *Config {
+	if c == nil {
+		return nil
+	}
+	n := *c
+	scopes := make(map[string][]string)
+	for k, v := range c.Auth.Scopes {
+		scopes[k] = append([]string{}, v...)
+	}
+	n.Auth.Scopes = scopes
+	return &n
+}
+
+func (c *Config) WithAuthSecret(s string) *Config {
+	c.Auth.DefaultSecret = s
+	return c
+}
+
+func (c *Config) WithFileURL(s string) *Config {
+	c.Files.BaseURL = s
+	return c
+}
+
+func (c *Config) WithDNSBaseURL(s string) *Config {
+	c.DNS.BaseURL = s
+	return c
+}
+
+// GetScopes returns the auth scopes for a given scope type
+func (c *Config) GetScopes(scopeType string) []string {
+	if c == nil {
+		return []string{}
+	}
+	if scopes, ok := c.Auth.Scopes[scopeType]; ok {
+		return scopes
+	}
+	return []string{}
+}
+
+// GetDefaultSecret returns the default secret name
+func (c *Config) GetDefaultSecret() string {
+	if c == nil {
+		return ""
+	}
+	return c.Auth.DefaultSecret
+}

--- a/util/sgcp/config_test.go
+++ b/util/sgcp/config_test.go
@@ -1,0 +1,108 @@
+package sgcp
+
+import (
+	"embed"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	//go:embed text
+	fs embed.FS
+)
+
+func Setup(t *testing.T) (cleanup func()) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	OrigDefaultConfigPath := DefaultConfigPath
+	DefaultConfigPath = filepath.Join(tmpDir, "sgcp.yaml")
+	cleanup = func() {
+		DefaultConfigPath = OrigDefaultConfigPath
+	}
+	return cleanup
+}
+
+func InstallConfig(t *testing.T) {
+	t.Helper()
+	b, err := fs.ReadFile("text/config.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(DefaultConfigPath, b, 0755))
+}
+
+// TestGetScopes tests the GetScopes function
+func TestGetScopes(t *testing.T) {
+	defer Setup(t)()
+	InstallConfig(t)
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	scopes := cfg.GetScopes("custom_admin")
+	assert.Equal(t, []string{"custom:read", "custom:write"}, scopes)
+
+	// Test unknown scope
+	scopes = cfg.GetScopes("unknown")
+	assert.Equal(t, []string{}, scopes)
+}
+
+// TestGetDefaultSecret tests the GetDefaultSecret function
+func TestGetDefaultSecret(t *testing.T) {
+	defer Setup(t)()
+	InstallConfig(t)
+
+	config, err := LoadConfig()
+	require.NoError(t, err)
+
+	secret := config.GetDefaultSecret()
+	assert.Equal(t, "the-secret", secret)
+}
+
+// TestDefaultConfigPath tests the default config path value
+func TestDefaultConfigPath(t *testing.T) {
+	assert.Equal(t, "/etc/om3/sgcp.yaml", DefaultConfigPath)
+}
+
+// TestGetConfig tests the global config getter when no config exists
+func TestGetConfigWhenNotPresnt(t *testing.T) {
+	defer Setup(t)()
+	cfg, err := LoadConfig()
+	assert.NotNil(t, err)
+	assert.Nil(t, cfg)
+}
+
+// TestLoadConfig tests loading the configuration from a file
+func TestLoadConfig(t *testing.T) {
+	defer Setup(t)()
+	InstallConfig(t)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	// Test files configuration
+	assert.Equal(t, "https://127.0.0.1:1215/file", cfg.Files.BaseURL)
+	assert.Equal(t, "/fs", cfg.Files.Path.FS)
+	assert.Equal(t, "/client", cfg.Files.Path.Client)
+	assert.Equal(t, "/cg", cfg.Files.Path.CG)
+
+	// Test DNS configuration
+	assert.Equal(t, "https://127.0.0.1:1215/dns", cfg.DNS.BaseURL)
+	assert.Equal(t, "/alias", cfg.DNS.Path.Alias)
+	assert.Equal(t, "/zone", cfg.DNS.Path.Zone)
+
+	// Test auth configuration
+	assert.Equal(t, "https://127.0.0.1:1215/auth", cfg.Auth.BaseURL)
+	assert.Equal(t, "the-secret", cfg.Auth.DefaultSecret)
+	assert.Equal(t, []string{"files:read"}, cfg.Auth.Scopes["files_read"])
+	assert.Equal(t, []string{"files:write"}, cfg.Auth.Scopes["files_write"])
+	assert.Equal(t, 10, cfg.Auth.Timeout)
+	assert.Equal(t, 1140, cfg.Auth.TTLSeconds)
+
+	// Test cache configuration
+	assert.Equal(t, 14400, cfg.Cache.TTLSeconds)
+	assert.True(t, cfg.Cache.Enabled)
+}

--- a/util/sgcp/file.go
+++ b/util/sgcp/file.go
@@ -1,0 +1,113 @@
+package sgcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/opensvc/om3/v3/util/plog"
+)
+
+type (
+	// FilesAPI provides methods for file-related API operations
+	FilesAPI struct {
+		Api
+		config *Config
+	}
+
+	// NfsClient represents an NFS client with associated metadata and permissions for a specific filesystem.
+	NfsClient struct {
+		UUID               string `json:"uuid,omitempty"`
+		Host               string `json:"host"`
+		Permission         string `json:"permission"`
+		Protocol           string `json:"protocol"`
+		ConsistencyGroupID string `json:"consistencyGroupId,omitempty"`
+	}
+)
+
+// NewFilesAPI creates a new FilesAPI instance
+func NewFilesAPI(config *Config, client *http.Client, l *plog.Logger, tk tokenGetter) *FilesAPI {
+	return &FilesAPI{
+		config: config,
+		Api: Api{
+			client: client,
+			tk:     tk,
+			log:    l,
+		},
+	}
+}
+
+func (a *FilesAPI) GetFilesystem(ctx context.Context, uuid string) (method, url string, code int, data []byte, err error) {
+	method = http.MethodGet
+	url = a.getFilesystemURL(uuid)
+	code, data, err = a.do(ctx, method, url, nil, a.GetScopes("files_read")...)
+	return
+}
+
+func (a *FilesAPI) PostNFSClients(ctx context.Context, uuid string, client *NfsClient) (method, url string, code int, data []byte, err error) {
+	var b []byte
+	method = http.MethodPost
+	url = a.getNFSClientsURL(uuid)
+
+	b, err = json.Marshal(client)
+	if err != nil {
+		err = fmt.Errorf("failed to marshal NFS client: %w", err)
+		return
+	}
+	a.log.Infof("%s %s data=%s", method, url, string(b))
+	code, data, err = a.do(ctx, method, url, bytes.NewReader(b), a.GetScopes("files_write")...)
+	return
+}
+
+func (a *FilesAPI) DeleteNFSClients(ctx context.Context, fsUUID, clientUUID string) (method, url string, code int, data []byte, err error) {
+	method = http.MethodDelete
+	url = a.getNFSClientURL(fsUUID, clientUUID)
+
+	a.log.Infof("%s %s", method, url)
+	code, data, err = a.do(ctx, method, url, nil, a.GetScopes("files_write")...)
+	return
+}
+
+func (a *FilesAPI) GetScopes(scopeType string) []string {
+	return a.config.GetScopes(scopeType)
+}
+
+// getFilesystemURL constructs the URL for a specific filesystem
+func (a *FilesAPI) getFilesystemURL(uuid string) string {
+	return fmt.Sprintf("%s%s/%s", a.config.Files.BaseURL, a.config.Files.Path.FS, uuid)
+}
+
+// getNFSClientsURL constructs the URL for NFS clients of a filesystem
+func (a *FilesAPI) getNFSClientsURL(uuid string) string {
+	return fmt.Sprintf("%s%s/%s%s",
+		a.config.Files.BaseURL,
+		a.config.Files.Path.FS,
+		uuid,
+		a.config.Files.Path.Client)
+}
+
+// getNFSClientURL constructs the URL for a specific NFS client
+func (a *FilesAPI) getNFSClientURL(uuid, clientUUID string) string {
+	return fmt.Sprintf("%s%s/%s%s/%s",
+		a.config.Files.BaseURL,
+		a.config.Files.Path.FS,
+		uuid,
+		a.config.Files.Path.Client,
+		clientUUID)
+}
+
+// do is the function that executes the HTTP request
+func (a *FilesAPI) do(ctx context.Context, method, url string, body io.Reader, scopes ...string) (statusCode int, b []byte, err error) {
+	return a.Api.do(ctx, method, url, body, scopes...)
+}
+
+// GetConsistencyGroupURL constructs the URL for a specific consistency group
+func (a *FilesAPI) GetConsistencyGroupURL(uuid string) string {
+	return fmt.Sprintf("%s%s/%s",
+		a.config.Files.BaseURL,
+		a.config.Files.Path.CG,
+		uuid)
+}

--- a/util/sgcp/file_test.go
+++ b/util/sgcp/file_test.go
@@ -1,0 +1,109 @@
+package sgcp
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opensvc/om3/v3/util/plog"
+)
+
+// TestFilesAPIURLMethods tests URL construction for FilesAPI
+func TestFilesAPIURLMethods(t *testing.T) {
+	defer Setup(t)()
+	InstallConfig(t)
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	api := NewFilesAPI(cfg, nil, nil, nil)
+
+	// Test filesystem URL
+	assert.Equal(t, "https://127.0.0.1:1215/file/fs/test-uuid",
+		api.getFilesystemURL("test-uuid"))
+
+	// Test NFS clients URL
+	assert.Equal(t, "https://127.0.0.1:1215/file/fs/test-uuid/client",
+		api.getNFSClientsURL("test-uuid"))
+
+	// Test NFS client URL
+	assert.Equal(t, "https://127.0.0.1:1215/file/fs/test-uuid/client/client-uuid",
+		api.getNFSClientURL("test-uuid", "client-uuid"))
+
+	// Test consistency group URL
+	assert.Equal(t, "https://127.0.0.1:1215/file/cg/cg-uuid",
+		api.GetConsistencyGroupURL("cg-uuid"))
+}
+
+func TestGetFilesystem(t *testing.T) {
+	defer Setup(t)()
+	InstallConfig(t)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	// Create a test server
+	var calls []string
+	var apiCallCount int
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/file/fs/id1" && r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/json")
+			auth := r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			t.Logf("GET /file/fs/id1 for auth %s", auth)
+			w.WriteHeader(http.StatusOK)
+			calls = append(calls, r.URL.Path)
+			enc := json.NewEncoder(w)
+			enc.Encode(map[string]interface{}{"test": calls})
+			apiCallCount++
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	ts := httptest.NewUnstartedServer(handler)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:1215")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts.EnableHTTP2 = true
+	ts.Listener = ln
+	ts.StartTLS()
+	defer ts.Close()
+
+	client := ts.Client()
+	log := plog.NewDefaultLogger()
+	tk := &TTkBuilder{}
+	api := NewFilesAPI(cfg, client, log, tk)
+
+	ctx := context.Background()
+
+	t.Log("expecting all calls hits the api")
+	method, url, code, data1, err := api.GetFilesystem(ctx, "id1")
+	require.Contains(t, url, "/fs/id1")
+	require.Equal(t, "GET", method)
+	require.Equal(t, 200, code)
+	require.NoError(t, err)
+	t.Logf("First request result: %s", string(data1))
+	t.Logf("api calls count: %d %v", apiCallCount, calls)
+	assert.Equal(t, 1, apiCallCount)
+
+	method, url, code, data1, err = api.GetFilesystem(ctx, "id1")
+	require.Contains(t, url, "/fs/id1")
+	require.Equal(t, "GET", method)
+	require.Equal(t, 200, code)
+	require.NoError(t, err)
+	t.Logf("Second request result: %s", string(data1))
+	t.Logf("api calls count: %d %v", apiCallCount, calls)
+	assert.Equal(t, 2, apiCallCount)
+}

--- a/util/sgcp/main.go
+++ b/util/sgcp/main.go
@@ -1,0 +1,14 @@
+// Package sgcp provides utility functions for SGCP API interactions.
+// It uses a YAML configuration file to avoid hardcoding API paths in the code.
+package sgcp
+
+import (
+	"github.com/opensvc/om3/v3/util/file"
+)
+
+func IsDisabled(s string) bool {
+	if config.DisabledFlag == "" {
+		return false
+	}
+	return file.Exists(config.DisabledFlag)
+}

--- a/util/sgcp/text/config.yaml
+++ b/util/sgcp/text/config.yaml
@@ -1,0 +1,33 @@
+# SGCP API Configuration
+# This file contains all API paths for SGCP services
+# Do not hardcode API paths in the code - use this config instead
+
+files:
+  base_url: "https://127.0.0.1:1215/file"
+  path:
+    fs: "/fs"
+    client: "/client"
+    cg: "/cg"
+
+dns:
+  base_url: "https://127.0.0.1:1215/dns"
+  path:
+    alias: "/alias"
+    zone: "/zone"
+
+# Authentication and caching settings
+auth:
+  base_url: "https://127.0.0.1:1215/auth"
+  default_secret: "the-secret"
+  scopes:
+    files_read: ["files:read"]
+    files_write: ["files:write"]
+    dns_read: ["dns:read"]
+    dns_write: ["dns:write"]
+    custom_admin: ["custom:read", "custom:write"]
+  timeout: 10
+  ttl_seconds: 1140 # 19 minutes
+
+cache:
+  ttl_seconds: 14400  # 4 hours
+  enabled: true

--- a/util/sgcp/text/config.yaml
+++ b/util/sgcp/text/config.yaml
@@ -31,3 +31,5 @@ auth:
 cache:
   ttl_seconds: 14400  # 4 hours
   enabled: true
+
+disabled_flag: /var/lib/opensvc/sgcp_disabled


### PR DESCRIPTION
### Description

This pull request introduces the SGCP NFS filesystem resource driver (`resfssgcp_nfs`) along with several related updates:

- **New SGCP NFS Driver (`resfssgcp_nfs`)**:
  - Added `resfssgcp_nfs` package to support NFS filesystem resources.
  - Introduced configuration parameters (e.g., UUID, host, permissions, protocol).
  - Implemented SGCP API integration with NFS client management methods (`Start`, `Stop`, `Status`).
  - Registered the driver and its keywords in `driverdb` and `manifest.go`.

- **SGCP API Enhancements**:
  - Added `FilesAPI` to handle file-related SGCP operations.
  - Introduced configuration handling with a global config loader.
  - Enhanced API functionality with token caching via `TokenFactory`.

- **Refactoring and Utilities**:
  - Refactored `GetAuthInfo` and added utilities for batch decoding of objects.
  - Split `KeywordCheckRead` in `resfshost` into enabled and disabled variants.
  - Introduced `Outputter` struct in ageing cache for output management.

- **Other Drivers**:
  - Added implementations for `resfssgcp_nfs_cg` and `resipsgcp_dnsalias` drivers, including manifest registrations and keyword definitions.
