### PR TITLE
[rescontainerocibase] Stream stdout and stderr logs

### DIFF
--- a/drivers/rescontainerocibase/executor.go
+++ b/drivers/rescontainerocibase/executor.go
@@ -380,12 +380,15 @@ func (e *Executor) doExecRunLogs(ctx context.Context, a ...string) (<-chan []byt
 	// Create a command
 	cmd := exec.CommandContext(ctx, e.bin, cmdArgs...)
 
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stdout pipe: %w", err)
+	}
+
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get stderr pipe: %w", err)
 	}
-
-	cmd.Stdout = nil
 
 	// Start the command
 	if err := cmd.Start(); err != nil {
@@ -395,27 +398,40 @@ func (e *Executor) doExecRunLogs(ctx context.Context, a ...string) (<-chan []byt
 	// Create a channel for log lines
 	logChan := make(chan []byte)
 
-	// Read stderr in a goroutine
-	go func() {
-		defer close(logChan)
+	var wg sync.WaitGroup
+	readStream := func(name string, stream io.Reader) {
+		defer wg.Done()
 		buf := make([]byte, 4096)
 		for {
-			n, err := stderr.Read(buf)
-			if err != nil {
-				if err != io.EOF {
-					e.log().Warnf("error reading logs: %s", err)
-				}
-				break
-			}
+			n, err := stream.Read(buf)
 			if n > 0 {
 				// Copy the data to a new slice to avoid race conditions
 				data := make([]byte, n)
 				copy(data, buf[:n])
-				logChan <- data
+				select {
+				case logChan <- data:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if err != nil {
+				if err != io.EOF {
+					e.log().Warnf("error reading container logs %s: %s", name, err)
+				}
+				return
 			}
 		}
+	}
+
+	wg.Add(2)
+	go readStream("stdout", stdout)
+	go readStream("stderr", stderr)
+
+	go func() {
+		wg.Wait()
 		// Wait for command to finish
 		_ = cmd.Wait()
+		close(logChan)
 	}()
 
 	return logChan, nil

--- a/drivers/rescontainerocibase/executor.go
+++ b/drivers/rescontainerocibase/executor.go
@@ -404,6 +404,12 @@ func (e *Executor) doExecRunLogs(ctx context.Context, a ...string) (<-chan []byt
 		buf := make([]byte, 4096)
 		for {
 			n, err := stream.Read(buf)
+			if err != nil {
+				if err != io.EOF {
+					e.log().Warnf("error reading container logs %s: %s", name, err)
+				}
+				return
+			}
 			if n > 0 {
 				// Copy the data to a new slice to avoid race conditions
 				data := make([]byte, n)
@@ -413,12 +419,6 @@ func (e *Executor) doExecRunLogs(ctx context.Context, a ...string) (<-chan []byt
 				case <-ctx.Done():
 					return
 				}
-			}
-			if err != nil {
-				if err != io.EOF {
-					e.log().Warnf("error reading container logs %s: %s", name, err)
-				}
-				return
 			}
 		}
 	}

--- a/drivers/rescontainerocibase/executor_test.go
+++ b/drivers/rescontainerocibase/executor_test.go
@@ -1,0 +1,40 @@
+package rescontainerocibase
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutorDoExecRunLogsStreamsStdoutAndStderr(t *testing.T) {
+	t.Setenv("OSVC_CONTAINER_LOGS_HELPER", "1")
+
+	executor := &Executor{bin: os.Args[0]}
+	logChan, err := executor.doExecRunLogs(
+		context.Background(),
+		"-test.run=TestExecutorDoExecRunLogsHelperProcess$",
+	)
+	require.NoError(t, err)
+
+	var output strings.Builder
+	for data := range logChan {
+		output.Write(data)
+	}
+
+	require.Contains(t, output.String(), "log from stdout")
+	require.Contains(t, output.String(), "log from stderr")
+}
+
+func TestExecutorDoExecRunLogsHelperProcess(t *testing.T) {
+	if os.Getenv("OSVC_CONTAINER_LOGS_HELPER") != "1" {
+		return
+	}
+
+	_, _ = fmt.Fprintln(os.Stdout, "log from stdout")
+	_, _ = fmt.Fprintln(os.Stderr, "log from stderr")
+	os.Exit(0)
+}


### PR DESCRIPTION
## Summary

  Fix container log streaming so OpenSVC returns logs written to both stdout and
  stderr by Docker and Podman workloads.

  Before this change, the container executor only read stderr and explicitly
  discarded stdout. Workloads such as Redis, which write their logs to stdout,
  therefore returned an empty result through `om ... container logs`.

  ## Root cause

  The container executor only opened the command stderr pipe:

  ```go
  stderr, err := cmd.StderrPipe()
  ```

  The command stdout was discarded:

  ```go
  cmd.Stdout = nil
  ```

  Container runtimes preserve the stdout and stderr streams of the container
  process. The `docker logs` command writes them to the corresponding stdout and
  stderr streams of the Docker CLI.

  Consequently:

  - container stdout was discarded by OpenSVC;
  - only container stderr could be returned;
  - workloads logging exclusively to stdout appeared to have no logs.

  ## Fix

  The executor now:

  - opens both stdout and stderr pipes;
  - consumes both streams concurrently;
  - forwards data from both streams through the existing log channel;
  - copies each block before sending it through the channel;
  - reacts to context cancellation;
  - waits for both streams to reach EOF;
  - closes the log channel only after both readers have completed.

  The existing public interface remains unchanged:

  ```go
  Logs(context.Context, bool, int) (<-chan []byte, error)
  ```

  ## Test environment

  The fix was reproduced and validated on an OpenSVC single-node lab.

  ```text
  Node:      testnode
  Object:    lab/svc/redis
  Resource:  container#redis
  Driver:    container.docker
  Image:     redis:7-alpine
  State:     up
  ```

  Service status:

  ```console
  $ sudo om lab/svc/redis print status

  lab/svc/redis                      up
  └ instances
    └ testnode                       up  idle started
      └ resources
        └ container#redis  ...../..  up  docker redis:7-alpine
  ```

  The Docker container is running with the `json-file` log driver:

  ```text
  Container:  lab..redis.container.redis
  Log driver: json-file
  TTY:        false
  ```

  ## Reproduction before the fix

  Docker contains Redis logs:

  ```console
  $ sudo docker logs --tail 10 lab..redis.container.redis

  1:M 15 Jul 2026 04:36:33.106 * Increased maximum number of open files to 10032 (it was originally set to 1024).
  1:M 15 Jul 2026 04:36:33.106 * monotonic clock: POSIX clock_gettime
  1:M 15 Jul 2026 04:36:33.109 * Running mode=standalone, port=6379.
  1:M 15 Jul 2026 04:36:33.109 * Server initialized
  1:M 15 Jul 2026 04:36:33.109 * Loading RDB produced by version 7.4.9
  1:M 15 Jul 2026 04:36:33.110 * RDB age 5534 seconds
  1:M 15 Jul 2026 04:36:33.110 * RDB memory usage when created 0.93 Mb
  1:M 15 Jul 2026 04:36:33.110 * Done loading RDB, keys loaded: 0, keys expired: 0.
  1:M 15 Jul 2026 04:36:33.110 * DB loaded from disk: 0.000 seconds
  1:M 15 Jul 2026 04:36:33.110 * Ready to accept connections tcp
  ```

  However, OpenSVC returns no output:

  ```console
  $ sudo om lab/svc/redis container logs \
      --rid='container#redis' \
      --lines=10

  $
  ```

  This confirms that the logs exist in Docker but are lost in the OpenSVC
  container executor.

  ## Validation after the fix

  The patched `om` binary was built without replacing the installed binary:

  ```console
  $ go build -o /tmp/om3-fix ./cmd/om
  ```

  The same command now returns the Redis stdout logs:

  ```console
  $ sudo /tmp/om3-fix lab/svc/redis container logs \
      --rid='container#redis' \
      --lines=10

  1:M 15 Jul 2026 04:36:33.106 * Increased maximum number of open files to 10032 (it was originally set to 1024).
  1:M 15 Jul 2026 04:36:33.106 * monotonic clock: POSIX clock_gettime
  1:M 15 Jul 2026 04:36:33.109 * Running mode=standalone, port=6379.
  1:M 15 Jul 2026 04:36:33.109 * Server initialized
  1:M 15 Jul 2026 04:36:33.109 * Loading RDB produced by version 7.4.9
  1:M 15 Jul 2026 04:36:33.110 * RDB age 5534 seconds
  1:M 15 Jul 2026 04:36:33.110 * RDB memory usage when created 0.93 Mb
  1:M 15 Jul 2026 04:36:33.110 * Done loading RDB, keys loaded: 0, keys expired: 0.
  1:M 15 Jul 2026 04:36:33.110 * DB loaded from disk: 0.000 seconds
  1:M 15 Jul 2026 04:36:33.110 * Ready to accept connections tcp
  ```

  The result now matches `docker logs`.

  ## Automated regression test

  A regression test starts a helper process that writes distinct messages to
  stdout and stderr:

  ```text
  log from stdout
  log from stderr
  ```

  The test consumes the returned log channel and verifies that both messages are
  present.

  This test would fail with the previous implementation because the stdout marker
  was discarded.

  ## Validation commands

  Package tests:

  ```console
  $ go test ./drivers/rescontainerocibase -count=1

  ok github.com/opensvc/om3/v3/drivers/rescontainerocibase
  ```

  Race detector:

  ```console
  $ CGO_ENABLED=1 go test -race \
      ./drivers/rescontainerocibase \
      -run TestExecutorDoExecRunLogs \
      -count=1

  ok github.com/opensvc/om3/v3/drivers/rescontainerocibase
  ```

  Static analysis:

  ```console
  $ go vet ./drivers/rescontainerocibase
  ```

  No race was detected.

  ## Screenshots

  ### Before the fix
<img width="913" height="103" alt="image (3)" src="https://github.com/user-attachments/assets/3cde7fc3-4a3f-42be-9e82-705d9f01bffd" />


  ### After the fix

<img width="999" height="276" alt="image (4)" src="https://github.com/user-attachments/assets/34bfb383-ee3e-45b3-b7da-31a76c1f528b" />