### PR TITLE
fix: moove bloc err != nil (PR de suivi de #1068)

### DIFF
--- a/drivers/rescontainerocibase/executor.go
+++ b/drivers/rescontainerocibase/executor.go
@@ -404,12 +404,6 @@ func (e *Executor) doExecRunLogs(ctx context.Context, a ...string) (<-chan []byt
 		buf := make([]byte, 4096)
 		for {
 			n, err := stream.Read(buf)
-			if err != nil {
-				if err != io.EOF {
-					e.log().Warnf("error reading container logs %s: %s", name, err)
-				}
-				return
-			}
 			if n > 0 {
 				// Copy the data to a new slice to avoid race conditions
 				data := make([]byte, n)
@@ -419,6 +413,12 @@ func (e *Executor) doExecRunLogs(ctx context.Context, a ...string) (<-chan []byt
 				case <-ctx.Done():
 					return
 				}
+			}
+			if err != nil {
+				if err != io.EOF {
+					e.log().Warnf("error reading container logs %s: %s", name, err)
+				}
+				return
 			}
 		}
 	}


### PR DESCRIPTION
hello,

je me permet de refaire une PR pour remettre le bloc du traitement de err apres le n, car cela introduit une regression.
En effet, un io.Reader peut retourner simultanement des donnees et io.EOF (err), donc si on traite err avant n on risque de perdre le dernier bloc.
la doc Go : 
"Callers should always process the n > 0 bytes returned before considering the error err. Doing so correctly handles I/O errors that happen after reading some bytes and also both of the allowed EOF behaviors."
src : https://pkg.go.dev/io#Reader

merci,
Hugo